### PR TITLE
add docker-compose for pre-built image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # local env files
-.env*.local
+.env
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ with features that matter to them.
 
 ![Much features, so fun](docs/pixels/big-AGI-compo2b.png)
 
+## Docker 🐳
+
+### Pre-built image
+Add your OpenAI API key to the `.env` file, then in a terminal run:
+
+```bash
+docker-compose up
+```
+
+### Locally built image
+
+If you wish to build the image yourself, run
+
+```bash
+docker build -t big-agi .
+docker run --detach 'big-agi'
+``` 
+
 ## Code 🧩
 
 ![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=&logo=typescript&logoColor=white)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3.9'
+
+services:
+  big-agi:
+    image: ghcr.io/enricoros/big-agi:main
+    ports:
+      - 3000:3000
+    env_file:
+      - .env
+    command: ["next", "start", "-p", "3000" ]


### PR DESCRIPTION
Adds: 

- docker-compose.yaml with settings to use the image published in the repo.

Changes:
- adds section to README.md with instructions on how to use pre-built and locally built container options
- updates .gitignore to correctly handle .env files.