### PR TITLE
Prevent menus from hiding on small window height

### DIFF
--- a/src/common/components/appbar/ApplicationBar.tsx
+++ b/src/common/components/appbar/ApplicationBar.tsx
@@ -96,7 +96,7 @@ export function ApplicationBar(props: { sx?: SxProps }) {
 
     {/* Application-Menu Items */}
     {!!appMenuItems && <Menu
-      variant='plain' color='neutral' size='lg' placement='top-start' sx={{ minWidth: 320 }}
+      variant='plain' color='neutral' size='lg' sx={{ minWidth: 320, maxHeight: 'calc(100vh - 64px)', overflowY: 'auto' }}
       open={!!applicationMenuAnchor} anchorEl={applicationMenuAnchor} onClose={closeApplicationMenu}
       disablePortal={false}
     >
@@ -105,7 +105,7 @@ export function ApplicationBar(props: { sx?: SxProps }) {
 
     {/* Context-Menu Items */}
     <Menu
-      variant='plain' color='neutral' size='lg' placement='top-end' sx={{ minWidth: 280 }}
+      variant='plain' color='neutral' size='lg' sx={{ minWidth: 280, maxHeight: 'calc(100vh - 64px)', overflowY: 'auto' }}
       open={!!contextMenuAnchor} anchorEl={contextMenuAnchor} onClose={closeContextMenu}
       disablePortal={false}
     >


### PR DESCRIPTION
There's a bug where if the window height is less than the menu height, the menu disappears.
![big-agi-dropdown-bug](https://github.com/enricoros/big-agi/assets/310310/3c65b501-c58c-4964-ab03-f38e8b0d38b4)

Removing the `placement` prop and setting maxHeight seems to fix the issue.  It seems like Joy UI is already smart enough to place the menu correctly.
![big-agi-dropdown-fix](https://github.com/enricoros/big-agi/assets/310310/c0d1b681-92e2-4708-bb49-b8e56b53982e)
