### PR TITLE
Double Click to Edit: Add settings button to toggle setting

### DIFF
--- a/src/apps/chat/components/appbar/ConversationItem.tsx
+++ b/src/apps/chat/components/appbar/ConversationItem.tsx
@@ -123,6 +123,7 @@ export function ConversationItem(props: {
 
       )}
 
+      {/* // TODO: Commented code */}
       {/* Edit */}
       {/*<IconButton*/}
       {/*  variant='plain' color='neutral'*/}

--- a/src/apps/chat/components/appbar/ConversationItem.tsx
+++ b/src/apps/chat/components/appbar/ConversationItem.tsx
@@ -8,6 +8,7 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 
 import { DConversation, useChatStore } from '~/common/state/store-chats';
 import { InlineTextarea } from '~/common/components/InlineTextarea';
+import { useUIPreferencesStore } from '~/common/state/store-ui';
 import { SystemPurposes } from '../../../../data';
 
 
@@ -28,6 +29,7 @@ export function ConversationItem(props: {
   // state
   const [isEditingTitle, setIsEditingTitle] = React.useState(false);
   const [deleteArmed, setDeleteArmed] = React.useState(false);
+  const doubleClickToEdit = useUIPreferencesStore(state => state.doubleClickToEdit);
 
   // bind to conversation
   const cState = useChatStore(state => {
@@ -111,7 +113,7 @@ export function ConversationItem(props: {
       {/* Text */}
       {!isEditingTitle ? (
 
-        <Box onDoubleClick={handleEditBegin} sx={{ flexGrow: 1 }}>
+        <Box onDoubleClick={(e) => doubleClickToEdit ? handleEditBegin() : null } sx={{ flexGrow: 1 }}>
           {DEBUG_CONVERSATION_IDs ? props.conversationId.slice(0, 10) : title}{assistantTyping && '...'}
         </Box>
 

--- a/src/apps/chat/components/message/ChatMessage.tsx
+++ b/src/apps/chat/components/message/ChatMessage.tsx
@@ -172,9 +172,10 @@ export function ChatMessage(props: { message: DMessage, isBottom: boolean, onMes
 
   // external state
   const theme = useTheme();
-  const { showAvatars, renderMarkdown: _renderMarkdown } = useUIPreferencesStore(state => ({
+  const { showAvatars, renderMarkdown: _renderMarkdown, doubleClickToEdit } = useUIPreferencesStore(state => ({
     showAvatars: state.zenMode !== 'cleaner',
     renderMarkdown: state.renderMarkdown,
+    doubleClickToEdit: state.doubleClickToEdit,
   }), shallow);
   const renderMarkdown = _renderMarkdown && !fromSystem;
   const isImaginable = canUseProdia();
@@ -308,7 +309,7 @@ export function ChatMessage(props: { message: DMessage, isBottom: boolean, onMes
       {/* Edit / Blocks */}
       {!isEditing ? (
 
-        <Box sx={{ ...cssBlock, flexGrow: 0 }} onDoubleClick={handleMenuEdit}>
+        <Box sx={{ ...cssBlock, flexGrow: 0 }} onDoubleClick={(e) => doubleClickToEdit ? handleMenuEdit(e) : null }>
 
           {fromSystem && wasEdited && (
             <Typography level='body2' color='warning' sx={{ mt: 1, mx: 1.5 }}>modified by user - auto-update disabled</Typography>
@@ -378,7 +379,7 @@ export function ChatMessage(props: { message: DMessage, isBottom: boolean, onMes
           <MenuItem onClick={handleMenuEdit}>
             <ListItemDecorator><EditIcon /></ListItemDecorator>
             {isEditing ? 'Discard' : 'Edit'}
-            {!isEditing && <span style={{ opacity: 0.5, marginLeft: '8px' }}> (double-click)</span>}
+            {!isEditing && <span style={{ opacity: 0.5, marginLeft: '8px' }}>{doubleClickToEdit ? '(double-click)' : ''}</span>}
           </MenuItem>
           {isImaginable && isImaginableEnabled && (
             <MenuItem onClick={handleMenuImagine} disabled={!isImaginableEnabled || isImagining}>

--- a/src/apps/settings/UISettings.tsx
+++ b/src/apps/settings/UISettings.tsx
@@ -63,12 +63,14 @@ export function UISettings() {
   const {
     centerMode, setCenterMode,
     enterToSend, setEnterToSend,
+    doubleClickToEdit, setDoubleClickToEdit,
     renderMarkdown, setRenderMarkdown,
     showPurposeFinder, setShowPurposeFinder,
     zenMode, setZenMode,
   } = useUIPreferencesStore(state => ({
     centerMode: state.centerMode, setCenterMode: state.setCenterMode,
     enterToSend: state.enterToSend, setEnterToSend: state.setEnterToSend,
+    doubleClickToEdit: state.doubleClickToEdit, setDoubleClickToEdit: state.setDoubleClickToEdit,
     renderMarkdown: state.renderMarkdown, setRenderMarkdown: state.setRenderMarkdown,
     showPurposeFinder: state.showPurposeFinder, setShowPurposeFinder: state.setShowPurposeFinder,
     zenMode: state.zenMode, setZenMode: state.setZenMode,
@@ -77,6 +79,8 @@ export function UISettings() {
   const handleCenterModeChange = (event: React.ChangeEvent<HTMLInputElement>) => setCenterMode(event.target.value as 'narrow' | 'wide' | 'full' || 'wide');
 
   const handleEnterToSendChange = (event: React.ChangeEvent<HTMLInputElement>) => setEnterToSend(event.target.checked);
+
+  const handleDoubleClickToEditChange = (event: React.ChangeEvent<HTMLInputElement>) => setDoubleClickToEdit(event.target.checked);
 
   const handleZenModeChange = (event: React.ChangeEvent<HTMLInputElement>) => setZenMode(event.target.value as 'clean' | 'cleaner');
 
@@ -107,6 +111,16 @@ export function UISettings() {
         </Box>
         <Switch checked={enterToSend} onChange={handleEnterToSendChange}
                 endDecorator={enterToSend ? 'On' : 'Off'}
+                slotProps={{ endDecorator: { sx: { minWidth: 26 } } }} />
+      </FormControl>
+
+      <FormControl orientation='horizontal' sx={{ justifyContent: 'space-between' }}>
+        <Box>
+          <FormLabel>Double click to edit</FormLabel>
+          <FormHelperText>{doubleClickToEdit ? 'Double click' : 'Three dots'}</FormHelperText>
+        </Box>
+        <Switch checked={doubleClickToEdit} onChange={handleDoubleClickToEditChange}
+                endDecorator={doubleClickToEdit ? 'On' : 'Off'}
                 slotProps={{ endDecorator: { sx: { minWidth: 26 } } }} />
       </FormControl>
 

--- a/src/common/state/store-ui.ts
+++ b/src/common/state/store-ui.ts
@@ -54,6 +54,9 @@ interface UIPreferencesStore {
   enterToSend: boolean;
   setEnterToSend: (enterToSend: boolean) => void;
 
+  doubleClickToEdit: boolean;
+  setDoubleClickToEdit: (enterToSend: boolean) => void;
+
   renderMarkdown: boolean;
   setRenderMarkdown: (renderMarkdown: boolean) => void;
 
@@ -80,6 +83,9 @@ export const useUIPreferencesStore = create<UIPreferencesStore>()(
 
       enterToSend: true,
       setEnterToSend: (enterToSend: boolean) => set({ enterToSend }),
+
+      doubleClickToEdit: true,
+      setDoubleClickToEdit: (doubleClickToEdit: boolean) => set({ doubleClickToEdit }),
 
       renderMarkdown: false,
       setRenderMarkdown: (renderMarkdown: boolean) => set({ renderMarkdown }),


### PR DESCRIPTION
Hello 👋 , I love the app. Thanks for making it awesome and open source.

===

## Update Details 
When I go to highlight text in the chat window I double click on words a lot and it brings me to the edit window instead of selecting the word. 

This update adds a toggle setting to turn that feature on an off. (Default setting is `doubleClickToEdit: true`)