### PR TITLE
feature: A command to send messages as a system

### DIFF
--- a/src/apps/chat/AppChat.tsx
+++ b/src/apps/chat/AppChat.tsx
@@ -31,6 +31,7 @@ import { restoreConversationFromJson } from './exportImport';
 import { runAssistantUpdatingState } from './editors/chat-stream';
 import { runImageGenerationUpdatingState } from './editors/image-generate';
 import { runReActUpdatingState } from './editors/react-tangent';
+import { CmdSystemMessage } from '~/modules/llms/llm.client';
 
 
 const SPECIAL_ID_ALL_CHATS = 'all-chats';
@@ -112,6 +113,10 @@ export function AppChat() {
         if (CmdRunReact.includes(command) && chatLLMId) {
           setMessages(conversationId, history);
           return await runReActUpdatingState(conversationId, prompt, chatLLMId);
+        }
+        if (CmdSystemMessage.includes(command)) {
+          lastMessage.role = "system"
+          lastMessage.text = pieces[1].value
         }
         // if (CmdRunSearch.includes(command))
         //   return await run...

--- a/src/apps/chat/components/composer/Composer.tsx
+++ b/src/apps/chat/components/composer/Composer.tsx
@@ -426,7 +426,7 @@ export function Composer(props: {
   // const isProdiaConfigured = !requireUserKeyProdia || prodiaApiKey;
   const textPlaceholder: string = props.isDeveloperMode
     ? 'Tell me what you need, and drop source files...'
-    : /*isProdiaConfigured ?*/ 'Chat · /react · /imagine · drop text files...' /*: 'Chat · /react · drop text files...'*/;
+    : /*isProdiaConfigured ?*/ 'Chat · /react · /imagine · /system · drop text files...' /*: 'Chat · /react · drop text files...'*/;
 
   const isImmediate = props.chatModeId === 'immediate';
   const isFollowUp = props.chatModeId === 'immediate-follow-up';

--- a/src/apps/chat/components/message/ChatMessage.tsx
+++ b/src/apps/chat/components/message/ChatMessage.tsx
@@ -179,7 +179,7 @@ export function ChatMessage(props: { message: DMessage, isBottom: boolean, onMes
   }), shallow);
   const renderMarkdown = _renderMarkdown && !fromSystem;
   const isImaginable = canUseProdia();
-  const isImaginableEnabled = messageText?.length > 5 && !messageText.startsWith('https://images.prodia.xyz/') && !(messageText.startsWith('/imagine') || messageText.startsWith('/img'));
+  const isImaginableEnabled = messageText?.length > 5 && !messageText.startsWith('https://images.prodia.xyz/') && !(messageText.startsWith('/imagine') || messageText.startsWith('/img') || messageText.startsWith('/system')  || messageText.startsWith('/sys') || messageText.startsWith('/s'));
   const isSpeakable = canUseElevenLabs();
 
   const closeOperationsMenu = () => setMenuAnchor(null);

--- a/src/common/util/extractCommands.ts
+++ b/src/common/util/extractCommands.ts
@@ -1,8 +1,9 @@
 import { CmdRunProdia } from '~/modules/prodia/prodia.client';
 import { CmdRunReact } from '~/modules/aifn/react/react';
 import { CmdRunSearch } from '~/modules/google/search.client';
+import { CmdSystemMessage } from '~/modules/llms/llm.client';
 
-export const commands = [...CmdRunProdia, ...CmdRunSearch, ...CmdRunReact];
+export const commands = [...CmdRunProdia, ...CmdRunSearch, ...CmdRunReact, ...CmdSystemMessage];
 
 export interface SentencePiece {
   type: 'text' | 'cmd';

--- a/src/modules/llms/llm.client.ts
+++ b/src/modules/llms/llm.client.ts
@@ -3,6 +3,7 @@ import { OpenAI } from './openai/openai.types';
 import { findVendorById } from './vendor.registry';
 import { useModelsStore } from './store-llms';
 
+export const CmdSystemMessage: string[] = ['/system', '/sys', '/s'];
 
 export type ModelVendorCallChatFn = (llm: DLLM, messages: VChatMessageIn[], maxTokens?: number) => Promise<VChatMessageOut>;
 export type ModelVendorCallChatWithFunctionsFn = (llm: DLLM, messages: VChatMessageIn[], functions: VChatFunctionIn[], maxTokens?: number) => Promise<VChatMessageOrFunctionCallOut>;


### PR DESCRIPTION
I have implemented a new command to allow users to send messages labeled as "system". This is intended to allow users to test out behavior before using it directly with API. The system messages allow for better "steerability".