### PR TITLE
Enable User ID in environment and advanced model configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# [Optional] Set the user id for OpenAI and Helicone to track usage
+USER_ID=
+
 # [Recommended for local deployments] Backend API key for OpenAI, so that users don't need one (UI > this > '')
 OPENAI_API_KEY=
 # [Optional] Sets the "OpenAI-Organization" header field to support organization users (UI > this > '')

--- a/src/common/types/env.d.ts
+++ b/src/common/types/env.d.ts
@@ -4,6 +4,8 @@ declare namespace NodeJS {
 
   // available to the server-side
   interface ProcessEnv {
+    // OpenAI and Helicone
+    USER_ID: string;
 
     // LLM: OpenAI
     OPENAI_API_KEY: string;

--- a/src/modules/llms/openai/OpenAISourceSetup.tsx
+++ b/src/modules/llms/openai/OpenAISourceSetup.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-import { Box, Button, FormControl, FormHelperText, FormLabel, Input, Switch } from '@mui/joy';
 import SyncIcon from '@mui/icons-material/Sync';
+import { Box, Button, FormControl, FormHelperText, FormLabel, Input, Switch } from '@mui/joy';
 
 import { apiQuery } from '~/modules/trpc/trpc.client';
 
@@ -12,9 +12,9 @@ import { Link } from '~/common/components/Link';
 import { settingsCol1Width, settingsGap } from '~/common/theme';
 
 import { DLLM, DModelSource, DModelSourceId } from '../llm.types';
-import { OpenAI } from './openai.types';
-import { hasServerKeyOpenAI, isValidOpenAIApiKey, LLMOptionsOpenAI, ModelVendorOpenAI } from './openai.vendor';
 import { useModelsStore, useSourceSetup } from '../store-llms';
+import { OpenAI } from './openai.types';
+import { LLMOptionsOpenAI, ModelVendorOpenAI, hasServerKeyOpenAI, isValidOpenAIApiKey } from './openai.vendor';
 
 
 export function OpenAISourceSetup(props: { sourceId: DModelSourceId }) {
@@ -25,7 +25,7 @@ export function OpenAISourceSetup(props: { sourceId: DModelSourceId }) {
   // external state
   const {
     source, sourceLLMs, updateSetup,
-    normSetup: { heliKey, oaiHost, oaiKey, oaiOrg, moderationCheck },
+    normSetup: { heliKey, oaiHost, oaiKey, oaiOrg, moderationCheck, userId },
   } = useSourceSetup(props.sourceId, ModelVendorOpenAI.normalizeSetup);
 
   const hasModels = !!sourceLLMs.length;
@@ -106,6 +106,23 @@ export function OpenAISourceSetup(props: { sourceId: DModelSourceId }) {
       <Input
         variant='outlined' placeholder='sk-...'
         value={heliKey} onChange={event => updateSetup({ heliKey: event.target.value })}
+        sx={{ flexGrow: 1 }}
+      />
+    </FormControl>}
+
+    {showAdvanced && <FormControl orientation='horizontal' sx={{ flexWrap: 'wrap', justifyContent: 'space-between' }}>
+      <Box sx={{ minWidth: settingsCol1Width }}>
+        <FormLabel>
+          User ID
+        </FormLabel>
+        <FormHelperText sx={{ display: 'block' }}>
+            <Link level='body-sm' href='https://docs.helicone.ai/features/advanced-usage/user-metrics' target='_blank'>helicone</Link>, 
+            <Link level='body-sm' href='https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids' target='_blank'>OpenAI</Link>
+        </FormHelperText>
+      </Box>
+      <Input
+        variant='outlined' placeholder='big-agi'
+        value={userId} onChange={event => updateSetup({ userId: event.target.value })}
         sx={{ flexGrow: 1 }}
       />
     </FormControl>}

--- a/src/modules/llms/openai/openai.vendor.ts
+++ b/src/modules/llms/openai/openai.vendor.ts
@@ -1,7 +1,7 @@
 import { apiAsync } from '~/modules/trpc/trpc.client';
 
-import { DLLM, ModelVendor } from '../llm.types';
 import { VChatFunctionIn, VChatMessageIn, VChatMessageOrFunctionCallOut, VChatMessageOut } from '../llm.client';
+import { DLLM, ModelVendor } from '../llm.types';
 
 import { OpenAIIcon } from './OpenAIIcon';
 import { OpenAILLMOptions } from './OpenAILLMOptions';
@@ -19,6 +19,7 @@ export interface SourceSetupOpenAI {
   oaiHost: string;  // use OpenAI-compatible non-default hosts (full origin path)
   heliKey: string;  // helicone key (works in conjunction with oaiHost)
   moderationCheck: boolean;
+  userId: string; // user id for OpenAi and helicone if heliKey is present 
 }
 
 export interface LLMOptionsOpenAI {
@@ -45,6 +46,7 @@ export const ModelVendorOpenAI: ModelVendor<SourceSetupOpenAI, LLMOptionsOpenAI>
     oaiOrg: '',
     oaiHost: '',
     heliKey: '',
+    userId: '',
     moderationCheck: false,
     ...partialSetup,
   }),


### PR DESCRIPTION
the general concept is that if a `USER_ID` is set then it will be applied to both OpenAI and Helicone