### PR TITLE
Add chat drawer indicator for num conversations

### DIFF
--- a/src/apps/chat/components/applayout/ChatDrawerItems.tsx
+++ b/src/apps/chat/components/applayout/ChatDrawerItems.tsx
@@ -42,9 +42,10 @@ export function ChatDrawerItems(props: {
   }), shallow);
 
 
-  const hasChats = conversationIDs.length > 0;
-  const singleChat = conversationIDs.length === 1;
-  const maxReached = conversationIDs.length >= MAX_CONVERSATIONS;
+  const totalConversations = conversationIDs.length;
+  const hasChats = totalConversations > 0;
+  const singleChat = totalConversations === 1;
+  const maxReached = totalConversations >= MAX_CONVERSATIONS;
 
   const closeDrawerMenu = () => setLayoutDrawerAnchor(null);
 
@@ -146,7 +147,7 @@ export function ChatDrawerItems(props: {
     <MenuItem disabled={!hasChats} onClick={props.onDeleteAllConversations}>
       <ListItemDecorator><DeleteOutlineIcon /></ListItemDecorator>
       <Typography>
-        Delete all
+        Delete all ({totalConversations}/{MAX_CONVERSATIONS})
       </Typography>
     </MenuItem>
 


### PR DESCRIPTION
Simple indication of the number of chats currently being used out of the max chats.

The next goal is to add an edit button for the `ChatDrawerItems` be able to multi-select the chats to remove.

<img width="328" alt="Screenshot 2023-08-29 at 5 31 39 PM" src="https://github.com/enricoros/big-agi/assets/78645267/c00d4792-0ccd-4145-bce0-db89ef50432c">
