### PR TITLE
Switch from LocalStorage to IndexedDB for Chat History Storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@vercel/analytics": "^1.0.2",
         "browser-fs-access": "^0.34.1",
         "eventsource-parser": "^1.0.0",
+        "idb-keyval": "^6.2.1",
         "next": "^13.4.19",
         "pdfjs-dist": "3.9.179",
         "plantuml-encoder": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@vercel/analytics": "^1.0.2",
     "browser-fs-access": "^0.34.1",
     "eventsource-parser": "^1.0.0",
+    "idb-keyval": "^6.2.1",
     "next": "^13.4.19",
     "pdfjs-dist": "3.9.179",
     "plantuml-encoder": "^1.4.0",

--- a/src/apps/chat/components/applayout/ChatDrawerItems.tsx
+++ b/src/apps/chat/components/applayout/ChatDrawerItems.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { shallow } from 'zustand/shallow';
 
-import { Box, ListDivider, ListItemDecorator, MenuItem, Tooltip, Typography } from '@mui/joy';
+import { Box, ListDivider, ListItemDecorator, MenuItem, Typography } from '@mui/joy';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import FileUploadIcon from '@mui/icons-material/FileUpload';
 
-import { MAX_CONVERSATIONS, useChatStore } from '~/common/state/store-chats';
+import { useChatStore } from '~/common/state/store-chats';
 import { setLayoutDrawerAnchor } from '~/common/layout/store-applayout';
 import { useUIPreferencesStore } from '~/common/state/store-ui';
 
@@ -44,7 +44,6 @@ export function ChatDrawerItems(props: {
 
   const hasChats = conversationIDs.length > 0;
   const singleChat = conversationIDs.length === 1;
-  const maxReached = conversationIDs.length >= MAX_CONVERSATIONS;
 
   const closeDrawerMenu = () => setLayoutDrawerAnchor(null);
 
@@ -67,8 +66,6 @@ export function ChatDrawerItems(props: {
     if (!singleChat && conversationId)
       deleteConversation(conversationId);
   }, [deleteConversation, singleChat]);
-
-  const NewPrefix = maxReached && <Tooltip title={`Maximum limit: ${MAX_CONVERSATIONS} chats. Proceeding will remove the oldest chat.`}><Box sx={{ mr: 2 }}>⚠️</Box></Tooltip>;
 
   // grouping
   let sortedIds = conversationIDs;
@@ -98,9 +95,9 @@ export function ChatDrawerItems(props: {
     {/*  </Typography>*/}
     {/*</ListItem>*/}
 
-    <MenuItem disabled={maxReached || (!!topNewConversationId && topNewConversationId === props.conversationId)} onClick={handleNew}>
+    <MenuItem disabled={!!topNewConversationId && topNewConversationId === props.conversationId} onClick={handleNew}>
       <ListItemDecorator><AddIcon /></ListItemDecorator>
-      {NewPrefix}New
+      New
     </MenuItem>
 
     <ListDivider sx={{ mb: 0 }} />

--- a/src/apps/chat/components/applayout/ChatMenuItems.tsx
+++ b/src/apps/chat/components/applayout/ChatMenuItems.tsx
@@ -10,7 +10,7 @@ import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import ForkRightIcon from '@mui/icons-material/ForkRight';
 import SettingsSuggestIcon from '@mui/icons-material/SettingsSuggest';
 
-import { MAX_CONVERSATIONS, useChatStore } from '~/common/state/store-chats';
+import { useChatStore } from '~/common/state/store-chats';
 import { setLayoutMenuAnchor } from '~/common/layout/store-applayout';
 import { useUIPreferencesStore } from '~/common/state/store-ui';
 
@@ -28,7 +28,6 @@ export function ChatMenuItems(props: {
   const { showSystemMessages, setShowSystemMessages } = useUIPreferencesStore(state => ({
     showSystemMessages: state.showSystemMessages, setShowSystemMessages: state.setShowSystemMessages,
   }), shallow);
-  const maxConversationsReached: boolean = useChatStore(state => state.conversations.length >= MAX_CONVERSATIONS);
 
   // derived state
   const disabled = !props.conversationId || props.isConversationEmpty;
@@ -82,13 +81,13 @@ export function ChatMenuItems(props: {
 
     <ListDivider inset='startContent' />
 
-    <MenuItem disabled={disabled || maxConversationsReached} onClick={handleConversationDuplicate}>
+    <MenuItem disabled={disabled} onClick={handleConversationDuplicate}>
       <ListItemDecorator>
         {/*<Badge size='sm' color='success'>*/}
         <ForkRightIcon color='success' />
         {/*</Badge>*/}
       </ListItemDecorator>
-      Duplicate{maxConversationsReached && ' (max reached)'}
+      Duplicate
     </MenuItem>
 
     <MenuItem disabled={disabled} onClick={handleConversationFlatten}>


### PR DESCRIPTION
Partially Resolves: #137

This PR addresses the limitation of storing only 20 conversations in the chat history due to the max storage limit of LocalStorage. The solution proposed is to switch to IndexedDB for storing chat conversations, which has a higher storage limit and thus will allow for an unlimited number of conversations to be stored.

Key changes include:

1. Addition of `idb-keyval` package to interact with IndexedDB.

2. Removal of `MAX_CONVERSATIONS` constant and related logic that limited the number of stored conversations.

3. Modification of the `useChatStore` state to use IndexedDB for storage instead of LocalStorage.

4. Update of the `ChatDrawerItems.tsx` and `ChatMenuItems.tsx` components to remove the restrictions on maximum conversations.

By implementing these changes, users will no longer face the restriction of a limited number of stored conversations, improving the user experience and functionality of the chat feature.

Note: This PR includes a version bump to 3 in `store-chats.ts` to reflect the switch to IndexedDB.

![image](https://github.com/enricoros/big-agi/assets/3626859/2c493dd1-dfc7-4558-bf19-3a05d91fb787)

Storage limit on IndexedDB:

- **Firefox:** 10% of the total disk size. (up to 10GB)
- **Chrome:** 60% of the total disk space. (No max limit)