### PR TITLE
(feat): add support for cloudflare ai gateway openai endpoints

### DIFF
--- a/src/modules/llms/vendors/openai/OpenAISourceSetup.tsx
+++ b/src/modules/llms/vendors/openai/OpenAISourceSetup.tsx
@@ -84,11 +84,11 @@ export function OpenAISourceSetup(props: { sourceId: DModelSourceId }) {
           API Host
         </FormLabel>
         <FormHelperText sx={{ display: 'block' }}>
-          <Link level='body-sm' href='https://www.helicone.ai' target='_blank'>Helicone</Link>, ...
+          <Link level='body-sm' href='https://www.helicone.ai' target='_blank'>Helicone</Link>, <Link level='body-sm' href='https://developers.cloudflare.com/ai-gateway/' target='_blank'>Cloudflare</Link>
         </FormHelperText>
       </Box>
       <Input
-        variant='outlined' placeholder='e.g., oai.hconeai.com'
+        variant='outlined' placeholder='e.g., oai.hconeai.com or https://gateway.ai.cloudflare.com/v1/<ACCOUNT_TAG>/<GATEWAY_URL_SLUG>/openai'
         value={oaiHost} onChange={event => updateSetup({ oaiHost: event.target.value })}
         sx={{ flexGrow: 1 }}
       />


### PR DESCRIPTION
This PR adds support for Cloudflare AI Gateway endpoints in the API Host field of the advanced OpenAI model configuration.

Cloudflare AI Gateway endpoint URLs are intended to be used as a base path but big-agi expects a host name. I have added a block to detect if a gateway URL is entered in the API Host field (or set via the OPENAI_API_HOST env var) and re-format the host and path accordingly.

This enables simply copy-pasting your cloudflare gateway endpoint from the Cloudflare dashboard into the API Host field.

Before:

![screenshot_000445-zqjn2Ugx_05-10-2023_15h39m22s](https://github.com/enricoros/big-agi/assets/542319/d652073d-0bb5-4a53-8064-af29ce75b22c)

After: 

![screenshot_000446-L2wcQdUg_05-10-2023_15h41m42s](https://github.com/enricoros/big-agi/assets/542319/dd98a540-f6ca-449e-a4a8-1dc9a5340525)

