### PR TITLE
fix: "paste as markdown" global shortcut

### DIFF
--- a/src/apps/chat/components/composer/Composer.tsx
+++ b/src/apps/chat/components/composer/Composer.tsx
@@ -333,7 +333,7 @@ export function Composer(props: {
     }
   }, []);
 
-  useGlobalShortcut('v', true, false, handlePasteButtonClicked);
+  useGlobalShortcut('v', true, true, handlePasteButtonClicked);
 
   const handleTextareaCtrlV = async (e: React.ClipboardEvent) => {
 


### PR DESCRIPTION
It looks like "paste as markdown" is [supposed to be bound to Ctrl-Shift-V](https://github.com/enricoros/big-agi/commit/0fd14db84c42eb1a2e08b881370fbad4320a417e#diff-45d4d448a7f952ad23e564ad2e31f66257f5ed7dc0296bcdb0a1b4890747ea0fR85-R87), but the change binds it to Ctrl-V.  

The current Ctrl-V behavior interferes with regular copy and pasting in two ways:
- makes it impossible to copy-paste normal text into the chat input
- captures copy-paste when editing an existing chat message and pastes into the wrong box