### PR TITLE
[Visualize] Add custom instruction #218

### DIFF
--- a/src/modules/aifn/digrams/DiagramsModal.tsx
+++ b/src/modules/aifn/digrams/DiagramsModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Box, Button, ButtonGroup, CircularProgress, Divider, Grid, IconButton } from '@mui/joy';
+import { Box, Button, ButtonGroup, CircularProgress, Divider, Grid, IconButton, Input, FormControl, FormLabel } from '@mui/joy';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -48,6 +48,7 @@ export function DiagramsModal(props: { config: DiagramConfig, onClose: () => voi
   const [message, setMessage] = React.useState<DMessage | null>(null);
   const [diagramType, diagramComponent] = useFormRadio<DiagramType>('auto', diagramTypes, 'Visualize');
   const [diagramLanguage, languageComponent] = useFormRadio<DiagramLanguage>('plantuml', diagramLanguages, 'Style');
+  const [customInstruction, setCustomInstruction] = React.useState<string>('');
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const [abortController, setAbortController] = React.useState<AbortController | null>(null);
 
@@ -81,7 +82,7 @@ export function DiagramsModal(props: { config: DiagramConfig, onClose: () => voi
     const stepAbortController = new AbortController();
     setAbortController(stepAbortController);
 
-    const diagramPrompt = bigDiagramPrompt(diagramType, diagramLanguage, systemMessage.text, subject);
+    const diagramPrompt = bigDiagramPrompt(diagramType, diagramLanguage, systemMessage.text, subject, customInstruction);
 
     try {
       await streamChat(diagramLlm.id, diagramPrompt, stepAbortController.signal,
@@ -103,7 +104,7 @@ export function DiagramsModal(props: { config: DiagramConfig, onClose: () => voi
       setAbortController(null);
     }
 
-  }, [abortController, conversationId, diagramLanguage, diagramLlm, diagramType, subject]);
+  }, [abortController, conversationId, diagramLanguage, diagramLlm, diagramType, subject, customInstruction]);
 
 
   // [Effect] Auto-abort on unmount
@@ -149,6 +150,12 @@ export function DiagramsModal(props: { config: DiagramConfig, onClose: () => voi
         <Grid xs={12} xl={6}>
           {llmComponent}
         </Grid>
+        <Grid xs={12} md={6}>
+            <FormControl>
+              <FormLabel>Custom Instruction</FormLabel>
+              <Input title="Custom Instruction" placeholder='e.g. visualize as state' value={customInstruction}  onChange={(e) => setCustomInstruction(e.target.value)} />
+            </FormControl>
+          </Grid>
       </Grid>
     )}
 

--- a/src/modules/aifn/digrams/diagrams.data.ts
+++ b/src/modules/aifn/digrams/diagrams.data.ts
@@ -60,12 +60,15 @@ function plantumlDiagramPrompt(diagramType: DiagramType): { sys: string, usr: st
   }
 }
 
-export function bigDiagramPrompt(diagramType: DiagramType, diagramLanguage: DiagramLanguage, chatSystemPrompt: string, subject: string): VChatMessageIn[] {
+export function bigDiagramPrompt(diagramType: DiagramType, diagramLanguage: DiagramLanguage, chatSystemPrompt: string, subject: string, customInstruction: string): VChatMessageIn[] {
   const { sys, usr } = diagramLanguage === 'mermaid' ? mermaidDiagramPrompt(diagramType) : plantumlDiagramPrompt(diagramType);
+  if (customInstruction) {
+    customInstruction = 'Also consider the following instructions: ' + customInstruction;
+  }
   return [
     { role: 'system', content: sys },
     { role: 'system', content: chatSystemPrompt },
     { role: 'assistant', content: subject },
-    { role: 'user', content: usr },
+    { role: 'user', content: `${usr} ${customInstruction}` },
   ];
 }


### PR DESCRIPTION
#218 Implement Custom Instruction Input for Diagram Generation
 
This pull request introduces a feature to enhance the Visualize module's functionality by allowing users to input custom instructions for diagram generation. Previously, the module did not consider user-specific instructions and only tried to generate valid diagrams in PlantUML/Mermaid languages without user hints. With this update, users can now guide the diagram generation process more directly.

  **Changes made:**

- Added an input box for custom instructions, consistent with the existing UI design (label on top, input field below).
- When provided, the custom instruction is intelligently mixed into the diagram generation prompt at an appropriate place.
- This feature responds to the need expressed in issue [#218](https://github.com/enricoros/big-AGI/issues/218).

**Files changed:**

DiagramsModal.tsx: Included a new FormControl for custom instruction input.
diagrams.data.ts: Altered the bigDiagramPrompt function to integrate the customInstruction string.

This update aims to provide users with the flexibility to tailor diagram generation to their specific needs, enabling more precise and meaningful visualizations.

Looking forward to feedback and suggestions for any improvements.

Screenshot:
![Bild 16 12 23 um 23 34](https://github.com/enricoros/big-AGI/assets/1590910/d9a1178b-2480-427e-8218-d13991fbbd91)
