### PR TITLE
Replicate Personas #282

### DIFF
--- a/src/apps/chat/components/persona-selector/PersonaSelector.tsx
+++ b/src/apps/chat/components/persona-selector/PersonaSelector.tsx
@@ -205,8 +205,8 @@ export function PersonaSelector(props: { conversationId: DConversationId, runExa
               <div>
                 <ScienceIcon />
               </div>
-              <div>
-                YouTube persona creator
+              <div style={{ textAlign: 'center' }}>
+                Persona creator
               </div>
             </Button>
           </Grid>}

--- a/src/apps/personas/YTPersonaCreator.tsx
+++ b/src/apps/personas/YTPersonaCreator.tsx
@@ -39,7 +39,7 @@ function useTranscriptFromVideo(videoID: string | null) {
 
 const YouTubePersonaSteps: LLMChainStep[] = [
   {
-    name: 'Analyzing the transcript',
+    name: 'Analyzing the transcript / text',
     setSystem: 'You are skilled in analyzing and embodying diverse characters. You meticulously study transcripts to capture key attributes, draft comprehensive character sheets, and refine them for authenticity. Feel free to make assumptions without hedging, be concise and be creative.',
     addUserInput: true,
     addUser: 'Conduct comprehensive research on the provided transcript. Identify key characteristics of the speaker, including age, professional field, distinct personality traits, style of communication, narrative context, and self-awareness. Additionally, consider any unique aspects such as their use of humor, their cultural background, core values, passions, fears, personal history, and social interactions. Your output for this stage is an in-depth written analysis that exhibits an understanding of both the superficial and more profound aspects of the speaker\'s persona.',
@@ -102,7 +102,7 @@ export function YTPersonaCreator() {
   return <>
 
     <Typography level='title-sm' mb={4}>
-          AI Persona from YouTube or text
+          AI Persona from YouTube or Text
     </Typography>
     <Tabs defaultValue={0}>
       <TabList>
@@ -157,7 +157,7 @@ export function YTPersonaCreator() {
       <Card sx={{ mt: 2, boxShadow: 'md' }}>
         <CardContent>
           <Typography level='title-md' sx={{ mb: 1 }}>
-            {title || 'Transcript'}
+            {title || 'Transcript / Text'}
           </Typography>
           <Box>
             {!!thumbnailUrl && <picture><img src={thumbnailUrl} alt='YouTube Video Image' height={80} style={{ float: 'left', marginRight: 8 }} /></picture>}
@@ -185,7 +185,7 @@ export function YTPersonaCreator() {
     {/* Persona! */}
     {chainOutput && <Box sx={{ mt: 2 }}>
       <Typography level='title-lg'>
-        YouTuber Persona System Prompt
+        Persona System Prompt
       </Typography>
       <Card sx={{ boxShadow: 'md' }}>
         <CardContent sx={{

--- a/src/apps/personas/YTPersonaCreator.tsx
+++ b/src/apps/personas/YTPersonaCreator.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Alert, Box, Button, Card, CardContent, CircularProgress, Grid, IconButton, Input, LinearProgress, Tooltip, Typography } from '@mui/joy';
+import { Alert, Box, Button, Card, CardContent, CircularProgress, Grid, IconButton, Input, LinearProgress, Tooltip, Typography, Tabs, TabList, Tab, TabPanel } from '@mui/joy';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import WhatshotIcon from '@mui/icons-material/Whatshot';
 import YouTubeIcon from '@mui/icons-material/YouTube';
@@ -67,6 +67,7 @@ export function YTPersonaCreator() {
   const [videoURL, setVideoURL] = React.useState('');
   const [videoID, setVideoID] = React.useState('');
   const [personaTranscript, setPersonaTranscript] = React.useState<string | null>(null);
+  const [personaText, setPersonaText] = React.useState('');
 
   // external state
   const [diagramLlm, llmComponent] = useFormRadioLlmType();
@@ -93,41 +94,60 @@ export function YTPersonaCreator() {
     }
   };
 
+  // New handler for persona text change
+  const handlePersonaTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setPersonaText(e.target.value);
+  };
+
   return <>
 
-    <Box sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 1 }}>
-      <YouTubeIcon sx={{ color: '#f00' }} />
-      <Typography level='title-lg'>
-        YouTube -&gt; AI persona
-      </Typography>
-    </Box>
+    <Typography level='title-sm' mb={4}>
+          AI Persona from YouTube or text
+    </Typography>
+    <Tabs defaultValue={0}>
+      <TabList>
+        <Tab>From YouTube Video</Tab>
+        <Tab>From Text</Tab>
+      </TabList>
+      <TabPanel value={0}>
+      <Box sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 1 }}>
+          <YouTubeIcon sx={{ color: '#f00' }} />
+          <Typography level="title-lg">YouTube -&gt; AI persona</Typography>
+        </Box>
 
-    <form onSubmit={handleFetchTranscript}>
-      <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2 }}>
-        <Input
-          required
-          type='url'
-          fullWidth
-          variant='outlined'
-          placeholder='YouTube Video URL'
-          value={videoURL} onChange={handleVideoIdChange}
-          endDecorator={
-            <IconButton
-              variant='outlined' color='neutral'
-              onClick={() => setVideoURL('https://www.youtube.com/watch?v=M_wZpSEvOkc')}
-            >
-              <WhatshotIcon />
-            </IconButton>
-          }
-        />
-        <Button
-          type='submit'
-          variant='solid' disabled={isFetching || isTransforming} loading={isFetching}
-          sx={{ minWidth: 120 }}>
+        <form onSubmit={handleFetchTranscript}>
+          <Box sx={{ display: 'flex', flexDirection: 'row', gap: 2 }}>
+            <Input
+              required
+              type="url"
+              fullWidth
+              variant="outlined"
+              placeholder="YouTube Video URL"
+              value={videoURL}
+              onChange={handleVideoIdChange}
+              endDecorator={
+                <IconButton variant="outlined" color="neutral" onClick={() => setVideoURL('https://www.youtube.com/watch?v=M_wZpSEvOkc')}>
+                  <WhatshotIcon />
+                </IconButton>
+              }
+            />
+            <Button type="submit" variant="solid" disabled={isFetching || isTransforming || !videoURL  } loading={isFetching} sx={{ minWidth: 120 }}>
+              Create
+            </Button>
+          </Box>
+        </form>
+      </TabPanel>
+      <TabPanel value={1}>
+        {/* New text area for users to paste copied text */}
+        <Typography level="title-md" sx={{ mb: 1 }}>
+          Paste your text here
+        </Typography>
+        <textarea placeholder="Paste your text here..." value={personaText} onChange={handlePersonaTextChange} style={{ width: '100%', minHeight: '100px' }} />
+        <Button variant="solid" disabled={isFetching || isTransforming || !personaText} onClick={() => setPersonaTranscript(personaText)} sx={{ mt: 1, mb: 2 }}>
           Create
         </Button>
-      </Box>
-    </form>
+      </TabPanel>
+    </Tabs>
 
     {/* LLM selector (chat vs fast) */}
     {!isTransforming && !isFinished && llmComponent}


### PR DESCRIPTION
This feature addresses the need for a more versatile persona creation process as outlined in issue #282. By allowing direct text input, users can quickly and efficiently replicate personas based on a wide range of textual sources.

**Changes made:**
Implemented a tabbed interface in YTPersonaCreator.tsx to allow users to choose between creating a persona from a YouTube video or from pasted text. 

- YTPersonaCreator.tsx: Added imports for tab components, implemented tabbed interface, and added text input handling.
- Updated button states to ensure the 'Create' button is only active when there is input text or a valid YouTube URL.
- PersonaSelector.tsx: Title changed to reflect both use cases.

Looking forward to feedback and suggestions for further refinement.

Screenshots:
![Persona](https://github.com/enricoros/big-AGI/assets/1590910/c30e0ce9-02a6-4f95-bc70-da8d70d2d14c)
