### PR TITLE
[BUG] Reset values when switching between text and youtube mode

### DIFF
--- a/src/apps/personas/PersonaCreator.tsx
+++ b/src/apps/personas/PersonaCreator.tsx
@@ -70,6 +70,7 @@ export function PersonaCreator() {
   const [videoID, setVideoID] = React.useState('');
   const [personaTranscript, setPersonaTranscript] = React.useState<string | null>(null);
   const [personaText, setPersonaText] = React.useState('');
+  const [selectedTab, setSelectedTab] = React.useState(0);
 
   // external state
   const [personaLlm, llmComponent] = useFormRadioLlmType('Persona Creation Model');
@@ -78,6 +79,15 @@ export function PersonaCreator() {
   const { transcript, thumbnailUrl, title, isFetching, isError, error: transcriptError } =
     useTranscriptFromVideo(videoID);
   React.useEffect(() => setPersonaTranscript(transcript), [transcript]);
+
+  // Reset the relevant state when the selected tab changes
+  React.useEffect(() => {
+      // reset state
+      setVideoURL('');
+      setVideoID('');
+      setPersonaTranscript(null);
+      setPersonaText('');
+  }, [selectedTab]);
 
   // use the transformation sequence to create a persona
   const { isFinished, isTransforming, chainProgress, chainIntermediates, chainStepName, chainOutput, chainError, abortChain } =
@@ -107,7 +117,9 @@ export function PersonaCreator() {
       Create the <em>System Prompt</em> of an AI Persona from YouTube or Text.
     </Typography>
 
-    <Tabs defaultValue={0} variant='outlined'>
+    <Tabs defaultValue={0} variant='outlined'
+      value={selectedTab}
+      onChange={(event, newValue) => setSelectedTab(newValue as number)}>
       <TabList sx={{ minHeight: 48 }}>
         <Tab>From YouTube Video</Tab>
         <Tab>From Text</Tab>


### PR DESCRIPTION
The issue where the thumbnail and transcript from the YouTube tab persisted when switching to the Text tab has been resolved. 

This was achieved by introducing a new state variable to track the active tab and implementing a useEffect hook to reset the YouTube-related state when the user navigates to the Text tab, and vice versa. This ensures that the UI correctly reflects the content for the currently active tab without displaying residual data from the previous tab.