### PR TITLE
Allow specifying num_ctx for Ollama models

### DIFF
--- a/src/modules/llms/server/ollama/ollama.models.ts
+++ b/src/modules/llms/server/ollama/ollama.models.ts
@@ -79,7 +79,7 @@ export const OLLAMA_BASE_MODELS: { [key: string]: { description: string, pulls: 
   'tinydolphin': { description: 'An experimental 1.1B parameter model trained on the new Dolphin 2.8 dataset by Eric Hartford and based on TinyLlama.', pulls: 735, added: '20240126' },
   'stablelm2': { description: 'Stable LM 2 1.6B is a state-of-the-art 1.6 billion parameter small language model trained on multilingual data in English, Spanish, German, Italian, French, Portuguese, and Dutch.', pulls: 45, added: '20240126' },
   'duckdb-nsql': { description: '7B parameter text-to-SQL model made by MotherDuck and Numbers Station.', pulls: 42, added: '20240126' },
-  'command-r-plus': { description: 'Command R+ is a powerful, scalable large language model purpose-built to excel at real-world enterprise use cases.', pulls: 226000, parameters: {num_ctx: 128000} },
+  'command-r-plus': { description: 'Command R+ is a powerful, scalable large language model purpose-built to excel at real-world enterprise use cases.', pulls: 226000, parameters: 'num_ctx 128000' },
 };
 // export const OLLAMA_LAST_UPDATE: string = '20240126';
 export const OLLAMA_PREV_UPDATE: string = '20231220';

--- a/src/modules/llms/server/ollama/ollama.models.ts
+++ b/src/modules/llms/server/ollama/ollama.models.ts
@@ -13,7 +13,7 @@
  *
  * from: https://ollama.ai/library?sort=featured
  */
-export const OLLAMA_BASE_MODELS: { [key: string]: { description: string, pulls: number, added?: string } } = {
+export const OLLAMA_BASE_MODELS: { [key: string]: { description: string, pulls: number, added?: string, parameters?: any } } = {
   'llama2': { description: 'The most popular model for general use.', pulls: 259800 },
   'mistral': { description: 'The 7B model released by Mistral AI, updated to version 0.2', pulls: 165500 },
   'llava': { description: '🌋 A novel end-to-end trained large multimodal model that combines a vision encoder and Vicuna for general-purpose visual and language understanding.', pulls: 17000, added: '20231215' },
@@ -79,6 +79,7 @@ export const OLLAMA_BASE_MODELS: { [key: string]: { description: string, pulls: 
   'tinydolphin': { description: 'An experimental 1.1B parameter model trained on the new Dolphin 2.8 dataset by Eric Hartford and based on TinyLlama.', pulls: 735, added: '20240126' },
   'stablelm2': { description: 'Stable LM 2 1.6B is a state-of-the-art 1.6 billion parameter small language model trained on multilingual data in English, Spanish, German, Italian, French, Portuguese, and Dutch.', pulls: 45, added: '20240126' },
   'duckdb-nsql': { description: '7B parameter text-to-SQL model made by MotherDuck and Numbers Station.', pulls: 42, added: '20240126' },
+  'command-r-plus': { description: 'Command R+ is a powerful, scalable large language model purpose-built to excel at real-world enterprise use cases.', pulls: 226000, parameters: {num_ctx: 128000} },
 };
 // export const OLLAMA_LAST_UPDATE: string = '20240126';
 export const OLLAMA_PREV_UPDATE: string = '20231220';

--- a/src/modules/llms/server/ollama/ollama.router.ts
+++ b/src/modules/llms/server/ollama/ollama.router.ts
@@ -218,14 +218,9 @@ export const llmOllamaRouter = createTRPCRouter({
           let contextWindow = 4096;
           if (model.parameters) {
             // split the parameters into lines, and find one called "num_ctx ...spaces... number"
-            const paramsNumCtx = model.parameters.split('\n').find(line => line.startsWith('num_ctx '));
+            const paramsNumCtx = model.parameters.num_ctx;
             if (paramsNumCtx) {
-              const numCtxValue: string = paramsNumCtx.split(/\s+/)[1];
-              if (numCtxValue) {
-                const numCtxNumber: number = parseInt(numCtxValue);
-                if (!isNaN(numCtxNumber))
-                  contextWindow = numCtxNumber;
-              }
+              contextWindow = parseInt(paramsNumCtx);
             }
           }
 

--- a/src/modules/llms/server/ollama/ollama.router.ts
+++ b/src/modules/llms/server/ollama/ollama.router.ts
@@ -218,9 +218,14 @@ export const llmOllamaRouter = createTRPCRouter({
           let contextWindow = 4096;
           if (model.parameters) {
             // split the parameters into lines, and find one called "num_ctx ...spaces... number"
-            const paramsNumCtx = model.parameters.num_ctx;
+            const paramsNumCtx = model.parameters.split('\n').find(line => line.startsWith('num_ctx '));
             if (paramsNumCtx) {
-              contextWindow = parseInt(paramsNumCtx);
+              const numCtxValue: string = paramsNumCtx.split(/\s+/)[1];
+              if (numCtxValue) {
+                const numCtxNumber: number = parseInt(numCtxValue);
+                if (!isNaN(numCtxNumber))
+                  contextWindow = numCtxNumber;
+              }
             }
           }
 


### PR DESCRIPTION
Partially fixed #495 

It allows specifying model parameters for Ollama models. @enricoros, if this approach is acceptable, I can try to add model parameters for other models. 