### PR TITLE
Enhanced Gemini API Key Handling (TEST)

### DIFF
--- a/src/modules/llms/server/gemini/gemini.router.ts
+++ b/src/modules/llms/server/gemini/gemini.router.ts
@@ -22,7 +22,15 @@ const DEFAULT_GEMINI_HOST = 'https://generativelanguage.googleapis.com';
 
 export function geminiAccess(access: GeminiAccessSchema, modelRefId: string | null, apiPath: string): { headers: HeadersInit, url: string } {
 
-  const geminiKey = access.geminiKey || env.GEMINI_API_KEY || '';
+  let geminiKey: string;
+  if (access.geminiKey.includes(',')) {
+    // If access.geminiKey includes commas, treat it as a list of keys and choose a random one
+    const keys = access.geminiKey.split(',').map(key => key.trim()).filter(key => key.length > 0);
+    geminiKey = keys[Math.floor(Math.random() * keys.length)];
+  } else {
+    // Otherwise, treat it as a single key
+    geminiKey = access.geminiKey;
+  }
   const geminiHost = fixupHost(DEFAULT_GEMINI_HOST, apiPath);
 
   // update model-dependent paths

--- a/src/server/env.mjs
+++ b/src/server/env.mjs
@@ -34,6 +34,7 @@ export const env = createEnv({
 
     // LLM: Google AI's Gemini
     GEMINI_API_KEY: z.string().optional(),
+    GEMINI_API_KEYS: z.string().optional(),
 
     // LLM: Groq
     GROQ_API_KEY: z.string().optional(),


### PR DESCRIPTION
This fork introduces a more flexible way to handle Gemini API keys, allowing users to specify either a single key or a comma-separated list of keys through the existing GEMINI_API_KEY interface field.

**Current behavior:**
The original code only supports a single Gemini API key.

**Proposed behavior:**
If the GEMINI_API_KEY field contains a single value (no commas), it's treated as a single API key.
If the GEMINI_API_KEY field contains multiple values separated by commas, it's treated as a list of API keys. The application will randomly select one of these keys for each request to the Gemini API.

**Benefits:**
Increased robustness: Using multiple API keys can help prevent rate limiting issues and ensure uninterrupted access to the Gemini API.