### PR TITLE
link ssl3 for latest alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 FROM node:22-alpine AS base
 ENV NEXT_TELEMETRY_DISABLED 1
 
-
 # Dependencies
 FROM base AS deps
 WORKDIR /app
@@ -10,6 +9,9 @@ WORKDIR /app
 # Dependency files
 COPY package*.json ./
 COPY src/server/prisma ./src/server/prisma
+
+# link ssl3 for latest Alpine
+RUN sh -c '[ ! -e /lib/libssl.so.3 ] && ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3 || echo "Link already exists"'
 
 # Install dependencies, including dev (release builds should use npm ci)
 ENV NODE_ENV development


### PR DESCRIPTION
Add workaround to fix error below with the latest alpine image, refer to issue: https://github.com/prisma/prisma/issues/25817

https://github.com/enricoros/big-AGI/actions/runs/12429197385/job/34702205785#step:7:384
```log
#23 77.03 prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x".
#23 77.03 Please manually install OpenSSL and try installing Prisma again.
#23 77.03 [Error [PrismaClientInitializationError]: Unable to require(`/app/node_modules/.prisma/client/libquery_engine-linux-musl.so.node`).
#23 77.03 The Prisma engines do not seem to be compatible with your system. Please refer to the documentation about Prisma's system requirements: https://pris.ly/d/system-requirements
#23 77.03 
#23 77.03 Details: Error loading shared library libssl.so.1.1: No such file or directory (needed by /app/node_modules/.prisma/client/libquery_engine-linux-musl.so.node)] {
#23 77.03   clientVersion: '5.22.0',
#23 77.03   errorCode: undefined
#23 77.03 }
```
