### PR TITLE
fix(gemini): fix FormHelperText for safety settings visibility 

### DIFF
--- a/src/modules/llms/vendors/gemini/GeminiServiceSetup.tsx
+++ b/src/modules/llms/vendors/gemini/GeminiServiceSetup.tsx
@@ -87,13 +87,13 @@ export function GeminiServiceSetup(props: { serviceId: DModelsServiceId }) {
       </Select>
     </FormControl>}
 
-    <FormHelperText sx={{ display: 'block' }}>
+    {advanced.on && <FormHelperText sx={{ display: 'block' }}>
       Gemini has advanced <Link href='https://ai.google.dev/docs/safety_setting_gemini' target='_blank' noLinkStyle>
       safety settings</Link> on: harassment, hate speech,
       sexually explicit, civic integrity, and dangerous content, in addition to non-adjustable built-in filters.
       {/*By default, the model will block content with <em>medium and above</em> probability*/}
       {/*of being unsafe.*/}
-    </FormHelperText>
+    </FormHelperText>}
 
     {advanced.on && <FormTextField
       autoCompleteId='gemini-host'


### PR DESCRIPTION
fix(gemini): make FormHelperText for safety settings invisible when advanced is not activated