### PR TITLE
fix: prevent recursion in blocks text parser

### DIFF
--- a/src/modules/blocks/blocks.textparser.ts
+++ b/src/modules/blocks/blocks.textparser.ts
@@ -22,7 +22,7 @@ export function parseBlocksFromText(text: string): RenderBlockInputs {
     // codeBlock: /`{3,}([\S\x20]+)?\n([\s\S]*?)(`{3,}\n?|$)/g,
     // This is way more promising, but will either not perform a partial match (no match at all) or match a single line
     // codeBlock: /^( {0,3})`{3,}([^\n`]*)\n([\s\S]*?)(?:\n^\1`{3,}[^\S\n]*(?=\n|$))?/gm,
-    codeBlock: /`{3,}([^\n`]*)\n([\s\S]*?)(`{3,}(?=[ *\n]|$)|$)/g,
+    codeBlock: /^(?:\s*)`{3,}([^\n`]*)\n([\s\S]*?)(?:\n\s*`{3,}|$)/gm,
     htmlCodeBlock: /<!DOCTYPE html>([\s\S]*?)<\/html>/gi,
     svgBlock: /<svg (xmlns|width|viewBox)=([\s\S]*?)<\/svg>/g,
   };
@@ -60,8 +60,8 @@ export function parseBlocksFromText(text: string): RenderBlockInputs {
         const blockTitle: string = (match[1] || '').trim();
         // note: we don't trim blockCode to preserve leading spaces, however if the last line is only made of spaces or tabs, we trim that
         const blockCode: string = match[2].replace(/[\t ]+$/, '');
-        const blockEnd: string = match[3];
-        blocks.push({ bkt: 'code-bk', title: blockTitle, code: blockCode, lines: countLines(blockCode), isPartial: !blockEnd.startsWith('```') });
+        const isPartial = !match[0].trimEnd().endsWith('```');
+        blocks.push({ bkt: 'code-bk', title: blockTitle, code: blockCode, lines: countLines(blockCode), isPartial });
         break;
 
       case 'htmlCodeBlock':


### PR DESCRIPTION
closes: https://github.com/enricoros/big-AGI/issues/752

Fixes infinite recursion in the blocks text parser by improving the code block regex pattern and fixing partial block detection.

Changes:

- Improved code block regex to prevent catastrophic backtracking
- Fixed partial block detection logic
- Maintained existing functionality for code, HTML and SVG blocks
- Preserved proper whitespace handling