### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # BIG-AGI 🧠
 
+<!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/enricoros/big-AGI?lang=de) | 
+[Español](https://www.readme-i18n.com/enricoros/big-AGI?lang=es) | 
+[français](https://www.readme-i18n.com/enricoros/big-AGI?lang=fr) | 
+[日本語](https://www.readme-i18n.com/enricoros/big-AGI?lang=ja) | 
+[한국어](https://www.readme-i18n.com/enricoros/big-AGI?lang=ko) | 
+[Português](https://www.readme-i18n.com/enricoros/big-AGI?lang=pt) | 
+[Русский](https://www.readme-i18n.com/enricoros/big-AGI?lang=ru) | 
+[中文](https://www.readme-i18n.com/enricoros/big-AGI?lang=zh)
+
 Welcome to big-AGI, the AI suite for professionals that need function, form,
 simplicity, and speed. Powered by the latest models from 15 vendors and
 open-source servers, `big-AGI` offers best-in-class Chats,


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

The updated can be previewed in my forked repository: https://github.com/dowithless/big-AGI/tree/patch-1