### PR TITLE
Add thinking support for Claude 4.1 Opus and 4.5 Sonnet via OpenRouter

### DIFF
--- a/src/modules/llms/server/openai/models/openrouter.models.ts
+++ b/src/modules/llms/server/openai/models/openrouter.models.ts
@@ -97,7 +97,13 @@ export function openRouterInjectVariants(models: ModelDescriptionSchema[], model
   models.push(model);
 
   // inject thinking variants for Anthropic thinking models
-  const antThinkingModels = ['anthropic/claude-opus-4', 'anthropic/claude-sonnet-4', 'anthropic/claude-3-7-sonnet'];
+  const antThinkingModels = [
+    'anthropic/claude-opus-4.1',
+    'anthropic/claude-opus-4',
+    'anthropic/claude-sonnet-4.5',
+    'anthropic/claude-sonnet-4',
+    'anthropic/claude-3-7-sonnet'
+  ];
   if (antThinkingModels.includes(model.id)) {
 
     // create a thinking variant for the model, by setting 'idVariant' and modifying the label/description


### PR DESCRIPTION
This PR adds thinking support for the newer Anthropic models via OpenRouter:

- `anthropic/claude-opus-4.1`
- `anthropic/claude-sonnet-4.5`

Following the same pattern as the [previous PR](https://github.com/enricoros/big-AGI/pull/811) that added support for Claude 4 and Claude 3.7 Sonnet, this minimal change adds these new model IDs to the `antThinkingModels` array in `openrouter.models.ts`.