### PR TITLE
feat: Add Anthropic web search and web fetch tools support

### DIFF
--- a/src/common/stores/llms/llms.parameters.ts
+++ b/src/common/stores/llms/llms.parameters.ts
@@ -88,6 +88,14 @@ export const DModelParameterRegistry = {
     } as const,
   } as const,
 
+  llmVndAntWebTools: {
+    label: 'Web Tools',
+    type: 'enum' as const,
+    description: 'Enable web search and fetch capabilities',
+    values: ['off', 'search', 'fetch', 'search+fetch'] as const,
+    // No initialValue - defaults to undefined (off)
+  } as const,
+
   llmVndGeminiAspectRatio: {
     label: 'Aspect Ratio',
     type: 'enum' as const,

--- a/src/modules/aix/server/api/aix.wiretypes.ts
+++ b/src/modules/aix/server/api/aix.wiretypes.ts
@@ -426,6 +426,7 @@ export namespace AixWire_API {
     topP: z.number().min(0).max(1).optional(),
     forceNoStream: z.boolean().optional(),
     vndAntThinkingBudget: z.number().nullable().optional(),
+    vndAntWebTools: z.enum(['off', 'search', 'fetch', 'search+fetch']).optional(),
     vndGeminiAspectRatio: z.enum(['1:1', '2:3', '3:2', '3:4', '4:3', '9:16', '16:9', '21:9']).optional(),
     vndGeminiGoogleSearch: z.enum(['unfiltered', '1d', '1w', '1m', '6m', '1y']).optional(),
     vndGeminiShowThoughts: z.boolean().optional(),

--- a/src/modules/aix/server/dispatch/chatGenerate/adapters/anthropic.messageCreate.ts
+++ b/src/modules/aix/server/dispatch/chatGenerate/adapters/anthropic.messageCreate.ts
@@ -141,12 +141,37 @@ export function aixToAnthropicMessageCreate(model: AixAPI_Model, _chatGenerate: 
   // --- Tools ---
 
   // Allow/deny auto-adding hosted tools when custom tools are present
-  // const hasCustomTools = chatGenerate.tools?.some(t => t.type === 'function_call');
-  // const hasRestrictivePolicy = chatGenerate.toolsPolicy?.type === 'any' || chatGenerate.toolsPolicy?.type === 'function_call';
-  // const skipHostedToolsDueToCustomTools = hasCustomTools && hasRestrictivePolicy;
+  const hasCustomTools = chatGenerate.tools?.some(t => t.type === 'function_call');
+  const hasRestrictivePolicy = chatGenerate.toolsPolicy?.type === 'any' || chatGenerate.toolsPolicy?.type === 'function_call';
+  const skipHostedToolsDueToCustomTools = hasCustomTools && hasRestrictivePolicy;
 
-  // Hosted tools
-  // ...
+  // Hosted tools: Web Search and Web Fetch
+  if (model.vndAntWebTools && !skipHostedToolsDueToCustomTools) {
+    const tools = payload.tools || [];
+
+    // Add web search tool
+    if (model.vndAntWebTools === 'search' || model.vndAntWebTools === 'search+fetch') {
+      tools.push({
+        type: 'web_search_20250305',
+        name: 'web_search',
+        max_uses: 5, // reasonable default
+        // Could add more configuration based on future parameters
+      } as any);
+    }
+
+    // Add web fetch tool
+    if (model.vndAntWebTools === 'fetch' || model.vndAntWebTools === 'search+fetch') {
+      tools.push({
+        type: 'web_fetch_20250910',
+        name: 'web_fetch',
+        max_uses: 5, // reasonable default
+        citations: { enabled: true }, // enable citations by default
+        // Could add more configuration based on future parameters
+      } as any);
+    }
+
+    payload.tools = tools.length > 0 ? tools : undefined;
+  }
 
 
   // Preemptive error detection with server-side payload validation before sending it upstream

--- a/src/modules/aix/server/dispatch/chatGenerate/chatGenerate.dispatch.ts
+++ b/src/modules/aix/server/dispatch/chatGenerate/chatGenerate.dispatch.ts
@@ -36,15 +36,22 @@ export function createChatGenerateDispatch(access: AixAPI_Access, model: AixAPI_
 } {
 
   switch (access.dialect) {
-    case 'anthropic':
+    case 'anthropic': {
+      // Add web-fetch beta header if web fetch is enabled
+      const additionalBetaFeatures: string[] = [];
+      if (model.vndAntWebTools === 'fetch' || model.vndAntWebTools === 'search+fetch') {
+        additionalBetaFeatures.push('web-fetch-2025-09-10');
+      }
+
       return {
         request: {
-          ...anthropicAccess(access, model.id, '/v1/messages'),
+          ...anthropicAccess(access, model.id, '/v1/messages', additionalBetaFeatures),
           body: aixToAnthropicMessageCreate(model, chatGenerate, streaming),
         },
         demuxerFormat: streaming ? 'fast-sse' : null,
         chatGenerateParse: streaming ? createAnthropicMessageParser() : createAnthropicMessageParserNS(),
       };
+    }
 
     case 'gemini':
       /**

--- a/src/modules/aix/server/dispatch/wiretypes/anthropic.wiretypes.ts
+++ b/src/modules/aix/server/dispatch/wiretypes/anthropic.wiretypes.ts
@@ -223,11 +223,44 @@ export namespace AnthropicWire_Tools {
     name: z.literal('str_replace_editor'),
   });
 
+  const _WebSearch_20250305_schema = _ToolDefinitionBase_schema.extend({
+    type: z.enum(['web_search_20250305']),
+    name: z.literal('web_search'),
+
+    // tool configuration
+    max_uses: z.number().int().optional(),
+    allowed_domains: z.array(z.string()).optional(),
+    blocked_domains: z.array(z.string()).optional(),
+    user_location: z.object({
+      type: z.literal('approximate'),
+      city: z.string().optional(),
+      region: z.string().optional(),
+      country: z.string().optional(),
+      timezone: z.string().optional(),
+    }).optional(),
+  });
+
+  const _WebFetch_20250910_schema = _ToolDefinitionBase_schema.extend({
+    type: z.enum(['web_fetch_20250910']),
+    name: z.literal('web_fetch'),
+
+    // tool configuration
+    max_uses: z.number().int().optional(),
+    allowed_domains: z.array(z.string()).optional(),
+    blocked_domains: z.array(z.string()).optional(),
+    citations: z.object({
+      enabled: z.boolean(),
+    }).optional(),
+    max_content_tokens: z.number().int().optional(),
+  });
+
   export const ToolDefinition_schema = z.discriminatedUnion('type', [
     _CustomToolDefinition_schema,
     _ComputerUseTool_20241022_schema,
     _BashTool_20241022_schema,
     _TextEditor_20241022_schema,
+    _WebSearch_20250305_schema,
+    _WebFetch_20250910_schema,
   ]);
 
 }

--- a/src/modules/llms/server/anthropic/anthropic.models.ts
+++ b/src/modules/llms/server/anthropic/anthropic.models.ts
@@ -1,4 +1,4 @@
-import { LLM_IF_ANT_PromptCaching, LLM_IF_OAI_Chat, LLM_IF_OAI_Fn, LLM_IF_OAI_Reasoning, LLM_IF_OAI_Vision } from '~/common/stores/llms/llms.types';
+import { LLM_IF_ANT_PromptCaching, LLM_IF_OAI_Chat, LLM_IF_OAI_Fn, LLM_IF_OAI_Reasoning, LLM_IF_OAI_Vision, LLM_IF_Tools_WebSearch } from '~/common/stores/llms/llms.types';
 
 import type { ModelDescriptionSchema } from '../llm.server.types';
 
@@ -10,9 +10,9 @@ export const hardcodedAnthropicVariants: { [modelId: string]: Partial<ModelDescr
     idVariant: 'thinking',
     label: 'Claude Sonnet 4.5 (Thinking)',
     description: 'Claude Sonnet 4.5 with extended thinking mode enabled for complex reasoning',
-    parameterSpecs: [{ paramId: 'llmVndAntThinkingBudget', required: true, hidden: false }],
+    parameterSpecs: [{ paramId: 'llmVndAntThinkingBudget', required: true, hidden: false }, { paramId: 'llmVndAntWebTools' }],
     maxCompletionTokens: 64000,
-    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Vision, LLM_IF_OAI_Fn, LLM_IF_ANT_PromptCaching, LLM_IF_OAI_Reasoning],
+    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Vision, LLM_IF_OAI_Fn, LLM_IF_ANT_PromptCaching, LLM_IF_OAI_Reasoning, LLM_IF_Tools_WebSearch],
     benchmark: { cbaElo: 1451 + 1 }, // FALLBACK-UNTIL-AVAILABLE: claude-opus-4-1-20250805-thinking-16k + 1
   },
 
@@ -20,9 +20,9 @@ export const hardcodedAnthropicVariants: { [modelId: string]: Partial<ModelDescr
     idVariant: 'thinking',
     label: 'Claude Haiku 4.5 (Thinking)',
     description: 'Claude Haiku 4.5 with extended thinking mode - first Haiku model with reasoning capabilities',
-    parameterSpecs: [{ paramId: 'llmVndAntThinkingBudget', required: true, hidden: false }],
+    parameterSpecs: [{ paramId: 'llmVndAntThinkingBudget', required: true, hidden: false }, { paramId: 'llmVndAntWebTools' }],
     maxCompletionTokens: 64000,
-    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Vision, LLM_IF_OAI_Fn, LLM_IF_ANT_PromptCaching, LLM_IF_OAI_Reasoning],
+    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Vision, LLM_IF_OAI_Fn, LLM_IF_ANT_PromptCaching, LLM_IF_OAI_Reasoning, LLM_IF_Tools_WebSearch],
   },
 
   // Claude 4.1 models with thinking variants
@@ -63,9 +63,9 @@ export const hardcodedAnthropicVariants: { [modelId: string]: Partial<ModelDescr
     idVariant: 'thinking',
     label: 'Claude Sonnet 3.7 (Thinking)',
     description: 'Claude 3.7 with extended thinking mode enabled for complex reasoning',
-    parameterSpecs: [{ paramId: 'llmVndAntThinkingBudget', required: true, hidden: false }],
+    parameterSpecs: [{ paramId: 'llmVndAntThinkingBudget', required: true, hidden: false }, { paramId: 'llmVndAntWebTools' }],
     maxCompletionTokens: 64000,
-    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Vision, LLM_IF_OAI_Fn, LLM_IF_ANT_PromptCaching, LLM_IF_OAI_Reasoning],
+    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Vision, LLM_IF_OAI_Fn, LLM_IF_ANT_PromptCaching, LLM_IF_OAI_Reasoning, LLM_IF_Tools_WebSearch],
     benchmark: { cbaElo: 1385 }, // claude-3-7-sonnet-20250219-thinking-32k
   },
 
@@ -82,7 +82,8 @@ export const hardcodedAnthropicModels: (ModelDescriptionSchema & { isLegacy?: bo
     contextWindow: 200000,
     maxCompletionTokens: 64000,
     trainingDataCutoff: 'Jul 2025',
-    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Vision, LLM_IF_OAI_Fn, LLM_IF_ANT_PromptCaching],
+    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Vision, LLM_IF_OAI_Fn, LLM_IF_ANT_PromptCaching, LLM_IF_Tools_WebSearch],
+    parameterSpecs: [{ paramId: 'llmVndAntWebTools' }],
     // Note: Tiered pricing - ≤200K: $3/$15, >200K: $6/$22.50. Using lower tier as base.
     chatPrice: { input: 3, output: 15, cache: { cType: 'ant-bp', read: 0.30, write: 3.75, duration: 300 } },
     benchmark: { cbaElo: 1438 + 1 }, // FALLBACK-UNTIL-AVAILABLE: claude-opus-4-1-20250805 + 1
@@ -94,7 +95,8 @@ export const hardcodedAnthropicModels: (ModelDescriptionSchema & { isLegacy?: bo
     contextWindow: 200000,
     maxCompletionTokens: 64000,
     trainingDataCutoff: 'Jul 2025',
-    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Vision, LLM_IF_OAI_Fn, LLM_IF_ANT_PromptCaching],
+    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Vision, LLM_IF_OAI_Fn, LLM_IF_ANT_PromptCaching, LLM_IF_Tools_WebSearch],
+    parameterSpecs: [{ paramId: 'llmVndAntWebTools' }],
     chatPrice: { input: 1, output: 5, cache: { cType: 'ant-bp', read: 0.10, write: 1.25, duration: 300 } },
   },
 
@@ -144,7 +146,8 @@ export const hardcodedAnthropicModels: (ModelDescriptionSchema & { isLegacy?: bo
     contextWindow: 200000,
     maxCompletionTokens: 64000,
     trainingDataCutoff: 'Nov 2024',
-    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Vision, LLM_IF_OAI_Fn, LLM_IF_ANT_PromptCaching],
+    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Vision, LLM_IF_OAI_Fn, LLM_IF_ANT_PromptCaching, LLM_IF_Tools_WebSearch],
+    parameterSpecs: [{ paramId: 'llmVndAntWebTools' }],
     chatPrice: { input: 3, output: 15, cache: { cType: 'ant-bp', read: 0.30, write: 3.75, duration: 300 } },
     benchmark: { cbaElo: 1369 }, // claude-3-7-sonnet-20250219
   },

--- a/src/modules/llms/server/anthropic/anthropic.router.ts
+++ b/src/modules/llms/server/anthropic/anthropic.router.ts
@@ -78,7 +78,7 @@ const PER_MODEL_BETA_FEATURES: { [modelId: string]: string[] } = {
   ] as const,
 } as const;
 
-function _anthropicHeaders(modelId?: string): HeadersInit {
+function _anthropicHeaders(modelId?: string, additionalBetaFeatures?: string[]): HeadersInit {
 
   // accumulate the beta features
   const betaFeatures = [...DEFAULT_ANTHROPIC_BETA_FEATURES];
@@ -87,6 +87,9 @@ function _anthropicHeaders(modelId?: string): HeadersInit {
     for (const [key, value] of Object.entries(PER_MODEL_BETA_FEATURES))
       if (key.includes(modelId))
         betaFeatures.push(...value);
+  }
+  if (additionalBetaFeatures) {
+    betaFeatures.push(...additionalBetaFeatures);
   }
 
   return {
@@ -108,7 +111,7 @@ async function anthropicGETOrThrow<TOut extends object>(access: AnthropicAccessS
 //   return await fetchJsonOrTRPCThrow<TOut, TPostBody>({ url, method: 'POST', headers, body, name: 'Anthropic' });
 // }
 
-export function anthropicAccess(access: AnthropicAccessSchema, antModelIdForBetaFeatures: undefined | string, apiPath: string): { headers: HeadersInit, url: string } {
+export function anthropicAccess(access: AnthropicAccessSchema, antModelIdForBetaFeatures: undefined | string, apiPath: string, additionalBetaFeatures?: string[]): { headers: HeadersInit, url: string } {
   // API key
   const anthropicKey = access.anthropicKey || env.ANTHROPIC_API_KEY || '';
 
@@ -135,7 +138,7 @@ export function anthropicAccess(access: AnthropicAccessSchema, antModelIdForBeta
     headers: {
       'Accept': 'application/json',
       'Content-Type': 'application/json',
-      ..._anthropicHeaders(antModelIdForBetaFeatures),
+      ..._anthropicHeaders(antModelIdForBetaFeatures, additionalBetaFeatures),
       'X-API-Key': anthropicKey,
       ...(heliKey && { 'Helicone-Auth': `Bearer ${heliKey}` }),
     },

--- a/src/modules/llms/server/llm.server.types.ts
+++ b/src/modules/llms/server/llm.server.types.ts
@@ -78,6 +78,7 @@ const ModelParameterSpec_schema = z.object({
     'llmTopP',
     'llmForceNoStream',
     'llmVndAntThinkingBudget',
+    'llmVndAntWebTools',
     'llmVndGeminiAspectRatio',
     'llmVndGeminiGoogleSearch',
     'llmVndGeminiShowThoughts',


### PR DESCRIPTION
Note: creating a PR to roll an auto build and seeing if this works

- Add web search capability to Claude 3.7, 4.5 Sonnet and 4.5 Haiku models
- Implement simplified llmVndAntWebTools parameter with options: off, search, fetch, search+fetch
- Add web_search_20250305 and web_fetch_20250910 tool definitions to wire types
- Implement dynamic beta header injection for web-fetch-2025-09-10
- Update message adapter to inject tools based on configuration
- Add UI parameter support for web tools control

Implements requested feature for Anthropic's May 2025 web search API and September 2025 web fetch tool, providing similar UX to GPT-5 and o4-deep research functionality.

Fixes: #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)