### PR TITLE
fix(call): propagate speech recognition errors to UI

### DIFF
--- a/src/apps/call/Telephone.tsx
+++ b/src/apps/call/Telephone.tsx
@@ -314,6 +314,7 @@ export function Telephone(props: {
   const isMicEnabled = recognitionState.isAvailable;
   const isTTSEnabled = true;
   const isEnabled = isMicEnabled && isTTSEnabled;
+  const micErrorMessage = recognitionState.errorMessage;
 
 
   return <>
@@ -350,7 +351,7 @@ export function Telephone(props: {
       callerName={isConnected ? undefined : personaName}
       statusText={isRinging ? '' /*'is calling you'*/ : isDeclined ? 'call declined' : isEnded ? 'call ended' : callElapsedTime}
       regardingText={chatTitle}
-      micError={!isMicEnabled} speakError={!isTTSEnabled}
+      micError={!isMicEnabled} micErrorMessage={micErrorMessage} speakError={!isTTSEnabled}
     />
 
     {/* Live Transcript, w/ streaming messages, audio indication, etc. */}

--- a/src/apps/call/components/CallStatus.tsx
+++ b/src/apps/call/components/CallStatus.tsx
@@ -16,7 +16,7 @@ export function CallStatus(props: {
   callerName?: string,
   statusText: string,
   regardingText: string | null,
-  micError: boolean, speakError: boolean,
+  micError: boolean, micErrorMessage: string | null, speakError: boolean,
   // llmComponent?: React.JSX.Element,
 }) {
   return (
@@ -37,7 +37,7 @@ export function CallStatus(props: {
       </Typography>}
 
       {props.micError && <InlineError
-        severity='danger' error='Looks like this Browser may not support speech recognition. You can try Chrome on Windows or Android instead.' />}
+        severity='danger' error={props.micErrorMessage || 'Looks like this Browser may not support speech recognition. You can try Chrome on Windows or Android instead.'} />}
 
       {props.speakError && <InlineError
         severity='danger' error='Text-to-speech does not appear to be configured. Please set it up in Preferences > Voice.' />}


### PR DESCRIPTION
- Read recognitionState.errorMessage in Telephone component
- Pass error message to CallStatus component
- Display specific error messages instead of generic fallback
- Matches error handling pattern used in Chat/Composer

This ensures users see detailed error messages instead of generic Browser may not support text.

Fixes #829 by making speech recognition errors visible to users.