### PR TITLE
docs: remove Midori AI Subsystem section from installation guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -136,11 +136,6 @@ Deploy big-AGI on a Kubernetes cluster for enhanced scalability and management. 
 
 For more detailed instructions on Kubernetes deployment, including updating and troubleshooting, refer to our [Kubernetes Deployment Guide](deploy-k8s.md).
 
-### Midori AI Subsystem for Docker Deployment
-
-Follow the instructions found on [Midori AI Subsystem Site](https://io.midori-ai.xyz/subsystem/manager/)
-for your host OS. After completing the setup process, install the Big-AGI docker backend to the Midori AI Subsystem.
-
 ## Enterprise-Grade Installation
 
 For businesses seeking a fully-managed, scalable solution, consider our managed installations.


### PR DESCRIPTION
Removes the Midori AI Subsystem deployment section from the installation documentation, as the subsystem is being sunset (#902).

Closes #902

Generated with [Claude Code](https://claude.ai/code)