### PR TITLE
bug(issue-784): fixed 'Enter' trigger unexpected Chat under Input Method Editor

### DIFF
--- a/src/apps/chat/components/composer/Composer.tsx
+++ b/src/apps/chat/components/composer/Composer.tsx
@@ -125,6 +125,7 @@ export function Composer(props: {
   const [micContinuation, setMicContinuation] = React.useState(false);
   const [speechInterimResult, setSpeechInterimResult] = React.useState<SpeechResult | null>(null);
   const [sendStarted, setSendStarted] = React.useState(false);
+  const [isComposing, setIsComposing] = React.useState(false);
   const {
     chatExecuteMode,
     chatExecuteModeSendColor, chatExecuteModeSendLabel,
@@ -538,6 +539,14 @@ export function Composer(props: {
     isMobile && actileInterceptTextChange(e.target.value);
   }, [actileInterceptTextChange, isMobile, setComposeText]);
 
+  const handleCompositionStart = React.useCallback(() => {
+    setIsComposing(true);
+  }, []);
+
+  const handleCompositionEnd = React.useCallback(() => {
+    setIsComposing(false);
+  }, []);
+
   const handleTextareaKeyDown = React.useCallback(async (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // disable keyboard handling if the actile is visible
     if (actileInterceptKeydown(e))
@@ -545,6 +554,9 @@ export function Composer(props: {
 
     // Enter: primary action
     if (e.key === 'Enter') {
+      if (isComposing) {
+        return;
+      }
 
       // Alt (Windows) or Option (Mac) + Enter: append the message instead of sending it
       if (e.altKey && !e.metaKey && !e.ctrlKey) {
@@ -572,7 +584,7 @@ export function Composer(props: {
       }
     }
 
-  }, [actileInterceptKeydown, assistantAbortible, chatExecuteMode, composeText, enterIsNewline, handleSendAction, touchAltEnter, touchCtrlEnter, touchShiftEnter]);
+  }, [actileInterceptKeydown, assistantAbortible, chatExecuteMode, composeText, enterIsNewline, handleSendAction, isComposing, touchAltEnter, touchCtrlEnter, touchShiftEnter]);
 
 
   // Focus mode
@@ -866,6 +878,8 @@ export function Composer(props: {
                     value={composeText}
                     onChange={handleTextareaTextChange}
                     onKeyDown={handleTextareaKeyDown}
+                    onCompositionStart={handleCompositionStart}
+                    onCompositionEnd={handleCompositionEnd}
                     onPasteCapture={handleAttachCtrlV}
                     // onFocusCapture={handleFocusModeOn}
                     // onBlurCapture={handleFocusModeOff}


### PR DESCRIPTION
# Fix: IME composition Enter key handling

Fixes #784

## Problem

Enter key during IME composition (Chinese/Japanese/Korean) triggers message submission instead of completing text input.

## Solution

Add IME composition event handling to skip Enter key processing during composition:

- Track composition state with `isComposing`
- Add `onCompositionStart`/`onCompositionEnd` handlers
- Check `isComposing` in `handleTextareaKeyDown` before processing Enter

## Testing

✅ Tested with Chinese Pinyin。
