### PR TITLE
feat: Add LLM API (llmapi.ai) as LLM vendor

### DIFF
--- a/src/modules/backend/backend.router.ts
+++ b/src/modules/backend/backend.router.ts
@@ -54,6 +54,7 @@ export const backendRouter = createTRPCRouter({
         hasLlmDeepseek: !!env.DEEPSEEK_API_KEY,
         hasLlmGemini: !!env.GEMINI_API_KEY,
         hasLlmGroq: !!env.GROQ_API_KEY,
+        hasLlmLLMAPI: !!env.LLMAPI_API_KEY,
         hasLlmLocalAIHost: !!env.LOCALAI_API_HOST,
         hasLlmLocalAIKey: !!env.LOCALAI_API_KEY,
         hasLlmMistral: !!env.MISTRAL_API_KEY,

--- a/src/modules/backend/store-backend-capabilities.ts
+++ b/src/modules/backend/store-backend-capabilities.ts
@@ -14,6 +14,7 @@ export interface BackendCapabilities {
   hasLlmDeepseek: boolean;
   hasLlmGemini: boolean;
   hasLlmGroq: boolean;
+  hasLlmLLMAPI: boolean;
   hasLlmLocalAIHost: boolean;
   hasLlmLocalAIKey: boolean;
   hasLlmMistral: boolean;
@@ -55,6 +56,7 @@ const useBackendCapabilitiesStore = create<BackendStore>()(
     hasLlmDeepseek: false,
     hasLlmGemini: false,
     hasLlmGroq: false,
+    hasLlmLLMAPI: false,
     hasLlmLocalAIHost: false,
     hasLlmLocalAIKey: false,
     hasLlmMistral: false,

--- a/src/modules/llms/components/LLMVendorSetup.tsx
+++ b/src/modules/llms/components/LLMVendorSetup.tsx
@@ -12,6 +12,7 @@ import { AzureServiceSetup } from '../vendors/azure/AzureServiceSetup';
 import { DeepseekAIServiceSetup } from '../vendors/deepseek/DeepseekAIServiceSetup';
 import { GeminiServiceSetup } from '../vendors/gemini/GeminiServiceSetup';
 import { GroqServiceSetup } from '../vendors/groq/GroqServiceSetup';
+import { LLMAPIServiceSetup } from '../vendors/llmapi/LLMAPIServiceSetup';
 import { LMStudioServiceSetup } from '../vendors/lmstudio/LMStudioServiceSetup';
 import { LocalAIServiceSetup } from '../vendors/localai/LocalAIServiceSetup';
 import { MistralServiceSetup } from '../vendors/mistral/MistralServiceSetup';
@@ -38,6 +39,7 @@ const vendorSetupComponents: Record<ModelVendorId, React.ComponentType<{ service
   deepseek: DeepseekAIServiceSetup,
   googleai: GeminiServiceSetup,
   groq: GroqServiceSetup,
+  llmapi: LLMAPIServiceSetup,
   lmstudio: LMStudioServiceSetup,
   localai: LocalAIServiceSetup,
   mistral: MistralServiceSetup,

--- a/src/modules/llms/server/openai/openai.access.ts
+++ b/src/modules/llms/server/openai/openai.access.ts
@@ -4,7 +4,7 @@
  * This module only imports zod for schema definition and provides access logic
  * that works identically on server and client environments.
  *
- * Supports 15 OpenAI-compatible dialects: alibaba, azure, deepseek, groq, lmstudio,
+ * Supports 16 OpenAI-compatible dialects: alibaba, azure, deepseek, groq, llmapi, lmstudio,
  * localai, mistral, moonshot, openai, openpipe, openrouter, perplexity, togetherai, xai, zai
  */
 
@@ -22,6 +22,7 @@ import type { RequestAccessValues } from '../llm.server.types';
 const DEFAULT_ALIBABA_HOST = 'https://dashscope-intl.aliyuncs.com/compatible-mode';
 const DEFAULT_DEEPSEEK_HOST = 'https://api.deepseek.com';
 const DEFAULT_GROQ_HOST = 'https://api.groq.com/openai';
+const DEFAULT_LLMAPI_HOST = 'https://api.llmapi.ai';
 const DEFAULT_HELICONE_OPENAI_HOST = 'oai.hconeai.com';
 const DEFAULT_LMSTUDIO_HOST = 'http://localhost:1234';
 const DEFAULT_LOCALAI_HOST = 'http://127.0.0.1:8080';
@@ -111,7 +112,7 @@ export type OpenAIDialects = OpenAIAccessSchema['dialect'];
 export type OpenAIAccessSchema = z.infer<typeof openAIAccessSchema>;
 export const openAIAccessSchema = z.object({
   dialect: z.enum([
-    'alibaba', 'azure', 'deepseek', 'groq', 'lmstudio',
+    'alibaba', 'azure', 'deepseek', 'groq', 'llmapi', 'lmstudio',
     'localai', 'mistral', 'moonshot', 'openai', 'openpipe',
     'openrouter', 'perplexity', 'togetherai', 'xai', 'zai',
   ]),
@@ -186,6 +187,25 @@ export function openAIAccess(access: OpenAIAccessSchema, modelRefId: string | nu
           'Authorization': `Bearer ${groqKey}`,
         },
         url: groqHost + apiPath,
+      };
+
+    case 'llmapi':
+      let llmapiKey = access.oaiKey || env.LLMAPI_API_KEY || '';
+      const llmapiHost = llmsFixupHost(access.oaiHost || DEFAULT_LLMAPI_HOST, apiPath);
+
+      // Use function to select a random key if multiple keys are provided
+      llmapiKey = llmsRandomKeyFromMultiKey(llmapiKey);
+
+      if (!llmapiKey)
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing LLM API Key. Add it on the UI (Models Setup) or server side (your deployment).' });
+
+      return {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'Authorization': `Bearer ${llmapiKey}`,
+        },
+        url: llmapiHost + apiPath,
       };
 
     case 'lmstudio':

--- a/src/modules/llms/vendors/llmapi/LLMAPIServiceSetup.tsx
+++ b/src/modules/llms/vendors/llmapi/LLMAPIServiceSetup.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+
+import type { DModelsServiceId } from '~/common/stores/llms/llms.service.types';
+import { AlreadySet } from '~/common/components/AlreadySet';
+import { FormInputKey } from '~/common/components/forms/FormInputKey';
+import { InlineError } from '~/common/components/InlineError';
+import { Link } from '~/common/components/Link';
+import { SetupFormClientSideToggle } from '~/common/components/forms/SetupFormClientSideToggle';
+import { SetupFormRefetchButton } from '~/common/components/forms/SetupFormRefetchButton';
+import { useToggleableBoolean } from '~/common/util/hooks/useToggleableBoolean';
+
+import { ApproximateCosts } from '../ApproximateCosts';
+import { ModelVendorLLMAPI } from './llmapi.vendor';
+import { useLlmUpdateModels } from '../../llm.client.hooks';
+import { useServiceSetup } from '../useServiceSetup';
+
+
+const LLMAPI_REG_LINK = 'https://llmapi.ai';
+
+
+export function LLMAPIServiceSetup(props: { serviceId: DModelsServiceId }) {
+
+  // external state
+  const {
+    service, serviceAccess, serviceHasCloudTenantConfig, serviceHasLLMs,
+    serviceSetupValid, updateSettings,
+  } = useServiceSetup(props.serviceId, ModelVendorLLMAPI);
+
+  // derived state
+  const { clientSideFetch, oaiKey: llmapiKey } = serviceAccess;
+  const needsUserKey = !serviceHasCloudTenantConfig;
+
+  // advanced mode - initialize open if CSF is enabled, but let user toggle freely
+  const advanced = useToggleableBoolean(!!clientSideFetch);
+  const showAdvanced = advanced.on;
+
+  // key validation
+  const shallFetchSucceed = !needsUserKey || (!!llmapiKey && serviceSetupValid);
+  const showKeyError = !!llmapiKey && !serviceSetupValid;
+
+  // fetch models
+  const { isFetching, refetch, isError, error } =
+    useLlmUpdateModels(!serviceHasLLMs && shallFetchSucceed, service);
+
+
+  return <>
+
+    <ApproximateCosts serviceId={service?.id} />
+
+    <FormInputKey
+      autoCompleteId='llmapi-key' label='LLM API Key'
+      rightLabel={<>{needsUserKey
+        ? !llmapiKey && <Link level='body-sm' href={LLMAPI_REG_LINK} target='_blank'>API keys</Link>
+        : <AlreadySet />}
+      </>}
+      value={llmapiKey} onChange={value => updateSettings({ llmapiKey: value })}
+      required={needsUserKey} isError={showKeyError}
+      placeholder='...'
+    />
+
+    {showAdvanced && <SetupFormClientSideToggle
+      visible={!!llmapiKey}
+      checked={!!clientSideFetch}
+      onChange={on => updateSettings({ csf: on })}
+      helpText='Connect directly to LLM API from your browser instead of through the server.'
+    />}
+
+    <SetupFormRefetchButton refetch={refetch} disabled={/*!shallFetchSucceed ||*/ isFetching} loading={isFetching} error={isError} advanced={advanced} />
+
+    {isError && <InlineError error={error} />}
+
+  </>;
+}

--- a/src/modules/llms/vendors/llmapi/llmapi.vendor.ts
+++ b/src/modules/llms/vendors/llmapi/llmapi.vendor.ts
@@ -1,0 +1,47 @@
+import type { IModelVendor } from '../IModelVendor';
+import type { OpenAIAccessSchema } from '../../server/openai/openai.access';
+
+import { ModelVendorOpenAI } from '../openai/openai.vendor';
+
+
+interface DLLMAPIServiceSettings {
+  llmapiKey: string;
+  csf?: boolean;
+}
+
+export const ModelVendorLLMAPI: IModelVendor<DLLMAPIServiceSettings, OpenAIAccessSchema> = {
+  id: 'llmapi',
+  name: 'LLM API',
+  displayRank: 41,
+  displayGroup: 'cloud',
+  location: 'cloud',
+  instanceLimit: 1,
+  hasServerConfigKey: 'hasLlmLLMAPI',
+
+  /// client-side-fetch ///
+  csfAvailable: _csfLLMAPIAvailable,
+
+  // functions
+  initializeSetup: () => ({
+    llmapiKey: '',
+  }),
+  validateSetup: (setup) => {
+    return setup.llmapiKey?.length >= 8;
+  },
+  getTransportAccess: (partialSetup) => ({
+    dialect: 'llmapi',
+    clientSideFetch: _csfLLMAPIAvailable(partialSetup) && !!partialSetup?.csf,
+    oaiKey: partialSetup?.llmapiKey || '',
+    oaiOrg: '',
+    oaiHost: '',
+    heliKey: '',
+  }),
+
+  // OpenAI transport ('llmapi' dialect in 'access')
+  rpcUpdateModelsOrThrow: ModelVendorOpenAI.rpcUpdateModelsOrThrow,
+
+};
+
+function _csfLLMAPIAvailable(s?: Partial<DLLMAPIServiceSettings>) {
+  return !!s?.llmapiKey;
+}

--- a/src/modules/llms/vendors/vendors.registry.ts
+++ b/src/modules/llms/vendors/vendors.registry.ts
@@ -6,6 +6,7 @@ import { ModelVendorAzure } from './azure/azure.vendor';
 import { ModelVendorDeepseek } from './deepseek/deepseekai.vendor';
 import { ModelVendorGemini } from './gemini/gemini.vendor';
 import { ModelVendorGroq } from './groq/groq.vendor';
+import { ModelVendorLLMAPI } from './llmapi/llmapi.vendor';
 import { ModelVendorLMStudio } from './lmstudio/lmstudio.vendor';
 import { ModelVendorLocalAI } from './localai/localai.vendor';
 import { ModelVendorMistral } from './mistral/mistral.vendor';
@@ -29,6 +30,7 @@ export type ModelVendorId =
   | 'deepseek'
   | 'googleai'
   | 'groq'
+  | 'llmapi'
   | 'lmstudio'
   | 'localai'
   | 'mistral'
@@ -51,6 +53,7 @@ const MODEL_VENDOR_REGISTRY: Record<ModelVendorId, IModelVendor> = {
   deepseek: ModelVendorDeepseek,
   googleai: ModelVendorGemini,
   groq: ModelVendorGroq,
+  llmapi: ModelVendorLLMAPI,
   lmstudio: ModelVendorLMStudio,
   localai: ModelVendorLocalAI,
   mistral: ModelVendorMistral,

--- a/src/server/env.server.ts
+++ b/src/server/env.server.ts
@@ -62,6 +62,9 @@ export const env = createEnv({
     // LLM: Groq
     GROQ_API_KEY: z.string().optional(),
 
+    // LLM: LLM API (llmapi.ai)
+    LLMAPI_API_KEY: z.string().optional(),
+
     // LLM: LocalAI
     LOCALAI_API_HOST: z.url().optional(),
     LOCALAI_API_KEY: z.string().optional(),


### PR DESCRIPTION
## Summary
- Adds [LLM API](https://llmapi.ai) (llmapi.ai) as a new OpenAI-compatible vendor
- LLM API is a unified API gateway providing access to 120+ models across OpenAI, Anthropic, Google, xAI, Alibaba, Moonshot, and more
- Follows the existing Groq/xAI vendor pattern

## Changes
- Created `src/modules/llms/vendors/llmapi/llmapi.vendor.ts` - vendor definition
- Created `src/modules/llms/vendors/llmapi/LLMAPIServiceSetup.tsx` - setup UI component
- Modified `vendors.registry.ts` - registered vendor ID and instance
- Modified `openai.access.ts` - added `llmapi` dialect with `https://api.llmapi.ai` host
- Modified `store-backend-capabilities.ts` - added `hasLlmLLMAPI` capability flag
- Modified `backend.router.ts` - added `LLMAPI_API_KEY` env check
- Modified `env.server.ts` - added `LLMAPI_API_KEY` env var definition
- Modified `LLMVendorSetup.tsx` - registered setup component

## Test plan
- [ ] Set `LLMAPI_API_KEY` env var and verify "LLM API" appears in vendor list
- [ ] Verify model fetching populates the model dropdown
- [ ] Verify chat completions work with streaming
- [ ] Verify client-side fetch (CSF) toggle works when API key is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)