### PR TITLE
feat: add Avian as an LLM provider

### DIFF
--- a/src/common/components/icons/vendors/AvianIcon.tsx
+++ b/src/common/components/icons/vendors/AvianIcon.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+import { SvgIcon, SvgIconProps } from '@mui/joy';
+
+export function AvianIcon(props: SvgIconProps) {
+  return <SvgIcon viewBox='0 0 24 24' width='24' height='24' fill='currentColor' stroke='none' {...props}>
+    <path d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm-5.5 9.5l3-4.5h5l3 4.5-2.5 4h-6l-2.5-4z' />
+  </SvgIcon>;
+}

--- a/src/modules/aix/server/dispatch/chatGenerate/chatGenerate.dispatch.ts
+++ b/src/modules/aix/server/dispatch/chatGenerate/chatGenerate.dispatch.ts
@@ -196,6 +196,7 @@ export async function createChatGenerateDispatch(access: AixAPI_Access, model: A
       const _exhaustiveCheck: never = dialect;
     // fallthrough
     case 'alibaba':
+    case 'avian':
     case 'azure':
     case 'deepseek':
     case 'groq':
@@ -304,6 +305,7 @@ export async function createChatGenerateResumeDispatch(access: AixAPI_Access, re
     // fallthrough
     case 'alibaba':
     case 'anthropic':
+    case 'avian':
     case 'bedrock':
     case 'deepseek':
     case 'gemini':

--- a/src/modules/backend/backend.router.ts
+++ b/src/modules/backend/backend.router.ts
@@ -50,6 +50,7 @@ export const backendRouter = createTRPCRouter({
         // llms
         hasLlmAlibaba: !!env.ALIBABA_API_KEY || !!env.ALIBABA_API_HOST,
         hasLlmAnthropic: !!env.ANTHROPIC_API_KEY,
+        hasLlmAvian: !!env.AVIAN_API_KEY,
         hasLlmAzureOpenAI: !!env.AZURE_OPENAI_API_KEY && !!env.AZURE_OPENAI_API_ENDPOINT,
         hasLlmBedrock: !!env.BEDROCK_BEARER_TOKEN || (!!env.BEDROCK_ACCESS_KEY_ID && !!env.BEDROCK_SECRET_ACCESS_KEY),
         hasLlmDeepseek: !!env.DEEPSEEK_API_KEY,

--- a/src/modules/backend/store-backend-capabilities.ts
+++ b/src/modules/backend/store-backend-capabilities.ts
@@ -10,6 +10,7 @@ export interface BackendCapabilities {
   // llms
   hasLlmAlibaba: boolean;
   hasLlmAnthropic: boolean;
+  hasLlmAvian: boolean;
   hasLlmAzureOpenAI: boolean;
   hasLlmBedrock: boolean;
   hasLlmDeepseek: boolean;
@@ -52,6 +53,7 @@ const useBackendCapabilitiesStore = create<BackendStore>()(
     // initial values
     hasLlmAlibaba: false,
     hasLlmAnthropic: false,
+    hasLlmAvian: false,
     hasLlmBedrock: false,
     hasLlmAzureOpenAI: false,
     hasLlmDeepseek: false,

--- a/src/modules/llms/components/LLMVendorIcon.tsx
+++ b/src/modules/llms/components/LLMVendorIcon.tsx
@@ -11,6 +11,7 @@ import { PhRobot } from '~/common/components/icons/phosphor/PhRobot';
 // direct imports for all vendor icons - given we use them frequently, we won't consider lazy loading them
 import { AlibabaCloudIcon } from '~/common/components/icons/vendors/AlibabaCloudIcon';
 import { AnthropicIcon } from '~/common/components/icons/vendors/AnthropicIcon';
+import { AvianIcon } from '~/common/components/icons/vendors/AvianIcon';
 import { AzureIcon } from '~/common/components/icons/vendors/AzureIcon';
 import { BedrockIcon } from '~/common/components/icons/vendors/BedrockIcon';
 import { DeepseekIcon } from '~/common/components/icons/vendors/DeepseekIcon';
@@ -38,6 +39,7 @@ import { ZAIIcon } from '~/common/components/icons/vendors/ZAIIcon';
 const vendorIcons: Record<ModelVendorId, React.FunctionComponent<SvgIconProps>> = {
   alibaba: AlibabaCloudIcon,
   anthropic: AnthropicIcon,
+  avian: AvianIcon,
   azure: AzureIcon,
   bedrock: BedrockIcon,
   deepseek: DeepseekIcon,

--- a/src/modules/llms/components/LLMVendorIconSprite.tsx
+++ b/src/modules/llms/components/LLMVendorIconSprite.tsx
@@ -14,6 +14,7 @@ import { PhRobot } from '~/common/components/icons/phosphor/PhRobot';
 const VI: Record<ModelVendorId, string> = {
   alibaba: 'vi-alibaba',
   anthropic: 'vi-anthropic',
+  avian: 'vi-avian',
   azure: 'vi-azure',
   bedrock: 'vi-bedrock',
   deepseek: 'vi-deepseek',
@@ -55,6 +56,12 @@ export const VendorIconSpriteMemo = React.memo(function VendorIconSprite() {
         <symbol id={VI.anthropic} viewBox='10 15 225 225'>
           <g stroke='currentColor' fill='currentColor' strokeLinecap='round' strokeLinejoin='round'>
           <path d='M47.1 124.4l-30.1 76c0 .3 7.6.6 16.9.6h16.9l3.6-9.2 6-15.8 2.4-6.5 31.5-.3 31.5-.2 3 7.7 6.2 16 3.2 8.3h16.9c9.3 0 16.9-.2 16.9-.4s-8.5-21.7-18.9-47.8L123 77.2 111.8 49H94.5 77.2l-30.1 75.4zm57.3-10.4l9.6 25.2c0 .5-8.8.8-19.5.8s-19.5-.3-19.5-.8c0-.4 3.4-9.5 7.6-20.2l9.6-24.8c1.1-2.9 2.1-5.2 2.3-5s4.7 11.3 9.9 24.8zM140 50.2c0 .7 13.4 34.8 29.8 75.8l29.7 74.5 16.9.3c9.9.1 16.6-.1 16.4-.7-.1-.5-13.8-34.7-30.2-76l-30-75.1h-16.3c-12.4 0-16.3.3-16.3 1.2z' />
+          </g>
+        </symbol>
+
+        <symbol id={VI.avian} viewBox='0 0 24 24'>
+          <g fill='currentColor'>
+          <path d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm-5.5 9.5l3-4.5h5l3 4.5-2.5 4h-6l-2.5-4z' />
           </g>
         </symbol>
 

--- a/src/modules/llms/components/LLMVendorSetup.tsx
+++ b/src/modules/llms/components/LLMVendorSetup.tsx
@@ -8,6 +8,7 @@ import { findModelVendor, ModelVendorId } from '../vendors/vendors.registry';
 // direct imports for all vendor setup components - NOTE: we could lazy load if this becomes a performance issue
 import { AlibabaServiceSetup } from '../vendors/alibaba/AlibabaServiceSetup';
 import { AnthropicServiceSetup } from '../vendors/anthropic/AnthropicServiceSetup';
+import { AvianServiceSetup } from '../vendors/avian/AvianServiceSetup';
 import { AzureServiceSetup } from '../vendors/azure/AzureServiceSetup';
 import { BedrockServiceSetup } from '../vendors/bedrock/BedrockServiceSetup';
 import { DeepseekAIServiceSetup } from '../vendors/deepseek/DeepseekAIServiceSetup';
@@ -35,6 +36,7 @@ import { ZAIServiceSetup } from '~/modules/llms/vendors/zai/ZAIServiceSetup';
 const vendorSetupComponents: Record<ModelVendorId, React.ComponentType<{ serviceId: DModelsServiceId }>> = {
   alibaba: AlibabaServiceSetup,
   anthropic: AnthropicServiceSetup,
+  avian: AvianServiceSetup,
   azure: AzureServiceSetup,
   bedrock: BedrockServiceSetup,
   deepseek: DeepseekAIServiceSetup,

--- a/src/modules/llms/server/listModels.dispatch.ts
+++ b/src/modules/llms/server/listModels.dispatch.ts
@@ -33,6 +33,7 @@ import { wireOllamaListModelsSchema, wireOllamaModelInfoSchema } from './ollama/
 import type { OpenAIWire_API_Models_List } from '~/modules/aix/server/dispatch/wiretypes/openai.wiretypes';
 import { llmsHostnameMatches, OPENAI_API_PATHS, openAIAccess } from './openai/openai.access';
 import { alibabaModelFilter, alibabaModelSort, alibabaModelToModelDescription } from './openai/models/alibaba.models';
+import { avianModelFilter, avianModelSort, avianModelToModelDescription } from './openai/models/avian.models';
 import { azureDeploymentFilter, azureDeploymentToModelDescription, azureParseFromDeploymentsAPI } from './openai/models/azure.models';
 import { chutesAIHeuristic, chutesAIModelsToModelDescriptions } from './openai/models/chutesai.models';
 import { deepseekModelFilter, deepseekModelSort, deepseekModelToModelDescription } from './openai/models/deepseek.models';
@@ -377,6 +378,7 @@ function _listModelsCreateDispatch(access: AixAPI_Access, signal?: AbortSignal):
       });
 
     case 'alibaba':
+    case 'avian':
     case 'azure':
     case 'deepseek':
     case 'groq':
@@ -432,6 +434,12 @@ function _listModelsCreateDispatch(access: AixAPI_Access, signal?: AbortSignal):
                 .filter(({ id }) => alibabaModelFilter(id))
                 .map(({ id, created }) => alibabaModelToModelDescription(id, created))
                 .sort(alibabaModelSort);
+
+            case 'avian':
+              return maybeModels
+                .filter(({ id }) => avianModelFilter(id))
+                .map(({ id, created }) => avianModelToModelDescription(id, created))
+                .sort(avianModelSort);
 
             case 'azure':
               const azureOpenAIDeployments = azureParseFromDeploymentsAPI(maybeModels);

--- a/src/modules/llms/server/openai/models/avian.models.ts
+++ b/src/modules/llms/server/openai/models/avian.models.ts
@@ -1,0 +1,89 @@
+import { LLM_IF_OAI_Chat, LLM_IF_OAI_Fn, LLM_IF_OAI_Vision } from '~/common/stores/llms/llms.types';
+
+import type { ModelDescriptionSchema } from '../../llm.server.types';
+import { fromManualMapping, ManualMappings } from '../../models.mappings';
+
+
+/**
+ * Avian models.
+ * - API: https://api.avian.io/v1 (OpenAI-compatible)
+ * - updated: 2026-02-27
+ */
+const _knownAvianModels: ManualMappings = [
+
+  // DeepSeek V3.2
+  {
+    idPrefix: 'deepseek/deepseek-v3.2',
+    label: 'DeepSeek V3.2',
+    description: 'DeepSeek V3.2 MoE model. Strong reasoning and coding. 164K context, 65K max output.',
+    contextWindow: 163840,
+    maxCompletionTokens: 65536,
+    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Fn],
+    chatPrice: { input: 0.26, output: 0.38 },
+  },
+
+  // Moonshot Kimi K2.5
+  {
+    idPrefix: 'moonshotai/kimi-k2.5',
+    label: 'Kimi K2.5',
+    description: 'Moonshot AI Kimi K2.5 MoE model. Advanced agentic coding. 131K context, 8K max output.',
+    contextWindow: 131072,
+    maxCompletionTokens: 8192,
+    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Fn],
+    chatPrice: { input: 0.45, output: 2.20 },
+  },
+
+  // Z.ai GLM-5
+  {
+    idPrefix: 'z-ai/glm-5',
+    label: 'GLM-5',
+    description: 'Z.ai GLM-5 large language model. Strong multilingual and reasoning. 131K context, 16K max output.',
+    contextWindow: 131072,
+    maxCompletionTokens: 16384,
+    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Fn],
+    chatPrice: { input: 0.30, output: 2.55 },
+  },
+
+  // MiniMax M2.5
+  {
+    idPrefix: 'minimax/minimax-m2.5',
+    label: 'MiniMax M2.5',
+    description: 'MiniMax M2.5 model. 1M context window and 1M max output.',
+    contextWindow: 1048576,
+    maxCompletionTokens: 1048576,
+    interfaces: [LLM_IF_OAI_Chat, LLM_IF_OAI_Fn],
+    chatPrice: { input: 0.30, output: 1.10 },
+  },
+
+];
+
+
+export function avianModelFilter(modelId: string): boolean {
+  // accept all models from the Avian API
+  return true;
+}
+
+export function avianModelToModelDescription(modelId: string, modelCreated?: number): ModelDescriptionSchema {
+  return fromManualMapping(_knownAvianModels, modelId, modelCreated, undefined, {
+    idPrefix: modelId,
+    label: modelId.replaceAll(/[/_-]/g, ' '),
+    description: 'Avian model',
+    contextWindow: 131072,
+    interfaces: [LLM_IF_OAI_Chat],
+    hidden: true,
+  });
+}
+
+export function avianModelSort(a: ModelDescriptionSchema, b: ModelDescriptionSchema): number {
+  // sort hidden at the end
+  if (a.hidden && !b.hidden) return 1;
+  if (!a.hidden && b.hidden) return -1;
+
+  // sort as per their order in the known models
+  const aIndex = _knownAvianModels.findIndex(base => a.id.startsWith(base.idPrefix));
+  const bIndex = _knownAvianModels.findIndex(base => b.id.startsWith(base.idPrefix));
+  if (aIndex !== -1 && bIndex !== -1)
+    return aIndex - bIndex;
+
+  return a.id.localeCompare(b.id);
+}

--- a/src/modules/llms/server/openai/openai.access.ts
+++ b/src/modules/llms/server/openai/openai.access.ts
@@ -4,7 +4,7 @@
  * This module only imports zod for schema definition and provides access logic
  * that works identically on server and client environments.
  *
- * Supports 15 OpenAI-compatible dialects: alibaba, azure, deepseek, groq, lmstudio,
+ * Supports 16 OpenAI-compatible dialects: alibaba, avian, azure, deepseek, groq, lmstudio,
  * localai, mistral, moonshot, openai, openpipe, openrouter, perplexity, togetherai, xai, zai
  */
 
@@ -20,6 +20,7 @@ import type { RequestAccessValues } from '../llm.server.types';
 
 // configuration
 const DEFAULT_ALIBABA_HOST = 'https://dashscope-intl.aliyuncs.com/compatible-mode';
+const DEFAULT_AVIAN_HOST = 'https://api.avian.io';
 const DEFAULT_DEEPSEEK_HOST = 'https://api.deepseek.com';
 const DEFAULT_GROQ_HOST = 'https://api.groq.com/openai';
 const DEFAULT_HELICONE_OPENAI_HOST = 'oai.hconeai.com';
@@ -111,7 +112,7 @@ export type OpenAIDialects = OpenAIAccessSchema['dialect'];
 export type OpenAIAccessSchema = z.infer<typeof openAIAccessSchema>;
 export const openAIAccessSchema = z.object({
   dialect: z.enum([
-    'alibaba', 'azure', 'deepseek', 'groq', 'lmstudio',
+    'alibaba', 'avian', 'azure', 'deepseek', 'groq', 'lmstudio',
     'localai', 'mistral', 'moonshot', 'openai', 'openpipe',
     'openrouter', 'perplexity', 'togetherai', 'xai', 'zai',
   ]),
@@ -145,6 +146,24 @@ export function openAIAccess(access: OpenAIAccessSchema, modelRefId: string | nu
           'Accept': 'application/json',
         },
         url: alibabaOaiHost + apiPath,
+      };
+
+    case 'avian':
+      let avianKey = access.oaiKey || env.AVIAN_API_KEY || '';
+      const avianHost = llmsFixupHost(access.oaiHost || DEFAULT_AVIAN_HOST, apiPath);
+
+      // Use function to select a random key if multiple keys are provided
+      avianKey = llmsRandomKeyFromMultiKey(avianKey);
+
+      if (!avianKey || !avianHost)
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Avian API Key. Add it on the UI (Models Setup) or server side (your deployment).' });
+
+      return {
+        headers: {
+          'Authorization': `Bearer ${avianKey}`,
+          'Content-Type': 'application/json',
+        },
+        url: avianHost + apiPath,
       };
 
     case 'azure':

--- a/src/modules/llms/vendors/avian/AvianServiceSetup.tsx
+++ b/src/modules/llms/vendors/avian/AvianServiceSetup.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+
+import type { DModelsServiceId } from '~/common/stores/llms/llms.service.types';
+import { AlreadySet } from '~/common/components/AlreadySet';
+import { FormInputKey } from '~/common/components/forms/FormInputKey';
+import { InlineError } from '~/common/components/InlineError';
+import { Link } from '~/common/components/Link';
+import { SetupFormClientSideToggle } from '~/common/components/forms/SetupFormClientSideToggle';
+import { SetupFormRefetchButton } from '~/common/components/forms/SetupFormRefetchButton';
+import { useToggleableBoolean } from '~/common/util/hooks/useToggleableBoolean';
+
+import { ApproximateCosts } from '../ApproximateCosts';
+import { ModelVendorAvian } from './avian.vendor';
+import { useLlmUpdateModels } from '../../llm.client.hooks';
+import { useServiceSetup } from '../useServiceSetup';
+
+
+const AVIAN_REG_LINK = 'https://avian.io';
+
+
+export function AvianServiceSetup(props: { serviceId: DModelsServiceId }) {
+
+  // external state
+  const {
+    service, serviceAccess, serviceHasCloudTenantConfig, serviceHasLLMs,
+    serviceSetupValid, updateSettings,
+  } = useServiceSetup(props.serviceId, ModelVendorAvian);
+
+  // derived state
+  const { clientSideFetch, oaiKey: avianKey } = serviceAccess;
+  const needsUserKey = !serviceHasCloudTenantConfig;
+
+  // advanced mode - initialize open if CSF is enabled, but let user toggle freely
+  const advanced = useToggleableBoolean(!!clientSideFetch);
+  const showAdvanced = advanced.on;
+
+  // key validation
+  const shallFetchSucceed = !needsUserKey || (!!avianKey && serviceSetupValid);
+  const showKeyError = !!avianKey && !serviceSetupValid;
+
+  // fetch models
+  const { isFetching, refetch, isError, error } =
+    useLlmUpdateModels(!serviceHasLLMs && shallFetchSucceed, service);
+
+
+  return <>
+
+    <ApproximateCosts serviceId={service?.id} />
+
+    <FormInputKey
+      autoCompleteId='avian-key' label='Avian API Key'
+      rightLabel={<>{needsUserKey
+        ? !avianKey && <Link level='body-sm' href={AVIAN_REG_LINK} target='_blank'>API keys</Link>
+        : <AlreadySet />}
+      </>}
+      value={avianKey} onChange={value => updateSettings({ avianKey: value })}
+      required={needsUserKey} isError={showKeyError}
+      placeholder='...'
+    />
+
+    {showAdvanced && <SetupFormClientSideToggle
+      visible={!!avianKey}
+      checked={!!clientSideFetch}
+      onChange={on => updateSettings({ csf: on })}
+      helpText='Connect directly to Avian API from your browser instead of through the server.'
+    />}
+
+    <SetupFormRefetchButton refetch={refetch} disabled={/*!shallFetchSucceed ||*/ isFetching} loading={isFetching} error={isError} advanced={advanced} />
+
+    {isError && <InlineError error={error} />}
+
+  </>;
+}

--- a/src/modules/llms/vendors/avian/avian.vendor.ts
+++ b/src/modules/llms/vendors/avian/avian.vendor.ts
@@ -1,0 +1,47 @@
+import type { IModelVendor } from '../IModelVendor';
+import type { OpenAIAccessSchema } from '../../server/openai/openai.access';
+
+import { ModelVendorOpenAI } from '../openai/openai.vendor';
+
+
+export interface DAvianServiceSettings {
+  avianKey: string;
+  csf?: boolean;
+}
+
+export const ModelVendorAvian: IModelVendor<DAvianServiceSettings, OpenAIAccessSchema> = {
+  id: 'avian',
+  name: 'Avian',
+  displayRank: 33,
+  displayGroup: 'cloud',
+  location: 'cloud',
+  instanceLimit: 1,
+  hasServerConfigKey: 'hasLlmAvian',
+
+  /// client-side-fetch ///
+  csfAvailable: _csfAvianAvailable,
+
+  // functions
+  initializeSetup: () => ({
+    avianKey: '',
+  }),
+  validateSetup: (setup) => {
+    return setup.avianKey?.length >= 8;
+  },
+  getTransportAccess: (partialSetup) => ({
+    dialect: 'avian',
+    clientSideFetch: _csfAvianAvailable(partialSetup) && !!partialSetup?.csf,
+    oaiKey: partialSetup?.avianKey || '',
+    oaiOrg: '',
+    oaiHost: '',
+    heliKey: '',
+  }),
+
+  // OpenAI transport ('Avian' dialect in 'access')
+  rpcUpdateModelsOrThrow: ModelVendorOpenAI.rpcUpdateModelsOrThrow,
+
+};
+
+function _csfAvianAvailable(s?: Partial<DAvianServiceSettings>) {
+  return !!s?.avianKey;
+}

--- a/src/modules/llms/vendors/vendors.registry.ts
+++ b/src/modules/llms/vendors/vendors.registry.ts
@@ -2,6 +2,7 @@ import type { AixAPI_Access } from '~/modules/aix/server/api/aix.wiretypes';
 
 import { ModelVendorAlibaba } from './alibaba/alibaba.vendor';
 import { ModelVendorAnthropic } from './anthropic/anthropic.vendor';
+import { ModelVendorAvian } from './avian/avian.vendor';
 import { ModelVendorAzure } from './azure/azure.vendor';
 import { ModelVendorBedrock } from './bedrock/bedrock.vendor';
 import { ModelVendorDeepseek } from './deepseek/deepseekai.vendor';
@@ -26,6 +27,7 @@ import type { IModelVendor } from './IModelVendor';
 export type ModelVendorId =
   | 'alibaba'
   | 'anthropic'
+  | 'avian'
   | 'azure'
   | 'bedrock'
   | 'deepseek'
@@ -49,6 +51,7 @@ export type ModelVendorId =
 const MODEL_VENDOR_REGISTRY: Record<ModelVendorId, IModelVendor> = {
   alibaba: ModelVendorAlibaba,
   anthropic: ModelVendorAnthropic,
+  avian: ModelVendorAvian,
   azure: ModelVendorAzure,
   bedrock: ModelVendorBedrock,
   deepseek: ModelVendorDeepseek,

--- a/src/server/env.server.ts
+++ b/src/server/env.server.ts
@@ -41,6 +41,9 @@ export const env = createEnv({
     ALIBABA_API_HOST: z.url().optional(),
     ALIBABA_API_KEY: z.string().optional(),
 
+    // LLM: Avian
+    AVIAN_API_KEY: z.string().optional(),
+
     // LLM: Azure OpenAI
     AZURE_OPENAI_API_ENDPOINT: z.url().optional(),
     AZURE_OPENAI_API_KEY: z.string().optional(),


### PR DESCRIPTION
## Summary

Adds [Avian](https://avian.io) as a new OpenAI-compatible LLM provider. Avian provides access to multiple frontier models through a unified API at `https://api.avian.io/v1`, with Bearer token authentication.

### Models supported

| Model | Context | Max Output | Input Price | Output Price |
|-------|---------|------------|-------------|--------------|
| `deepseek/deepseek-v3.2` | 164K | 65K | $0.26/1M | $0.38/1M |
| `moonshotai/kimi-k2.5` | 131K | 8K | $0.45/1M | $2.20/1M |
| `z-ai/glm-5` | 131K | 16K | $0.30/1M | $2.55/1M |
| `minimax/minimax-m2.5` | 1M | 1M | $0.30/1M | $1.10/1M |

### Changes

Following the existing vendor pattern (same as Groq, Deepseek, etc.):

- **New vendor files**: `src/modules/llms/vendors/avian/` (vendor definition + setup UI)
- **New models file**: `src/modules/llms/server/openai/models/avian.models.ts`
- **New icon**: `src/common/components/icons/vendors/AvianIcon.tsx`
- **Dialect registration**: Added `'avian'` to the OpenAI-compatible access layer schema
- **Vendor registry**: Registered in vendor registry, icon registry, sprite, and setup components
- **Server config**: Added `AVIAN_API_KEY` env var and `hasLlmAvian` backend capability
- **Dispatch**: Added to both chat generate and model listing dispatch switches

### Configuration

Users can configure via:
- **UI**: Enter API key in Models Setup > Avian
- **Server-side**: Set `AVIAN_API_KEY` environment variable
- **Client-side fetch**: Supported (direct browser-to-API connection)

## Test plan

- [ ] Verify the Avian vendor appears in the Models Setup dropdown
- [ ] Enter an Avian API key and verify models are fetched successfully
- [ ] Verify model metadata (context window, pricing) is displayed correctly
- [ ] Test chat completion with an Avian model
- [ ] Test streaming responses
- [ ] Verify client-side fetch toggle works
- [ ] Verify `AVIAN_API_KEY` server-side env var is picked up