### PR TITLE
store-chats: bump `updated` in setAutoTitle / setUserTitle

### DIFF
--- a/src/common/stores/chat/store-chats.ts
+++ b/src/common/stores/chat/store-chats.ts
@@ -420,12 +420,14 @@ export const useChatStore = create<ConversationsStore>()(/*devtools(*/
         _get()._editConversation(conversationId,
           {
             autoTitle,
+            updated: Date.now(),
           }),
 
       setUserTitle: (conversationId: DConversationId, userTitle: string) =>
         _get()._editConversation(conversationId,
           {
             userTitle,
+            updated: Date.now(),
             ...(!userTitle && { autoTitle: undefined }), // clear autotitle when clearing usertitle
           }),
 


### PR DESCRIPTION
Title mutations did not advance the conversation's `updated` timestamp, so any logic that tracks modifications by timestamp (exports, change detection, etc.) would silently miss renames.