### PR TITLE
feat: add Ctrl+( / Ctrl+) shortcuts to toggle left drawer and right panel

### DIFF
--- a/src/common/components/shortcuts/globalShortcutsHandler.ts
+++ b/src/common/components/shortcuts/globalShortcutsHandler.ts
@@ -37,6 +37,10 @@ function _handleGlobalShortcutKeyDown(event: KeyboardEvent) {
       (shortcut.shift && !event.shiftKey) || (!shortcut.shift && event.shiftKey))
       continue;
 
+    // Skip if a text input element is focused and the shortcut opts into this guard
+    if (shortcut.skipIfInput && _isTextInputFocused())
+      continue;
+
     // Execute the action (and prevent the default browser action)
     event.preventDefault();
     event.stopPropagation();
@@ -65,4 +69,23 @@ function _uninstallGlobalShortcutHandler() {
     window.removeEventListener('keydown', _handleGlobalShortcutKeyDown);
     isHandlerInstalled = false;
   }
+}
+
+/** Returns true if the active element (or an ancestor with focus) is a text input, textarea, or contenteditable. */
+function _isTextInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el || el === document.body)
+    return false;
+  if (el instanceof HTMLInputElement && (el.type === 'text' || el.type === 'search' || el.type === 'url' || el.type === 'email' || el.type === 'password' || el.type === 'number' || el.type === 'tel'))
+    return true;
+  if (el instanceof HTMLTextAreaElement)
+    return true;
+  // check the element and its ancestors for contenteditable
+  let node: Element | null = el;
+  while (node) {
+    if (node instanceof HTMLElement && node.isContentEditable)
+      return true;
+    node = node.parentElement;
+  }
+  return false;
 }

--- a/src/common/components/shortcuts/shortcutsCatalog.ts
+++ b/src/common/components/shortcuts/shortcutsCatalog.ts
@@ -53,4 +53,11 @@ export const shortcutsCatalog: ShortcutCatalogCategory[] = [
       { key: '/', ctrl: true, shift: true, description: 'Shortcuts' },
     ],
   },
+  {
+    label: 'Layout',
+    items: [
+      { key: '(', ctrl: true, shift: true, description: 'Toggle left drawer' },
+      { key: ')', ctrl: true, shift: true, description: 'Toggle right panel' },
+    ],
+  },
 ] as const;

--- a/src/common/components/shortcuts/useGlobalShortcuts.ts
+++ b/src/common/components/shortcuts/useGlobalShortcuts.ts
@@ -30,6 +30,7 @@ export interface ShortcutDefinition {
 
 export interface ShortcutObject extends ShortcutDefinition {
   disabled?: boolean;
+  skipIfInput?: boolean; // skip if a text input, textarea, contenteditable (or child thereof) is focused
   action: (() => void) | '_specialPrintShortcuts';
   endDecoratorIcon?: typeof SvgIcon;
   level?: number; // if set, it will exclusively show icons at that level of priority and hide the others

--- a/src/common/layout/optima/OptimaLayout.tsx
+++ b/src/common/layout/optima/OptimaLayout.tsx
@@ -22,7 +22,7 @@ import { MobileDrawer } from './drawer/MobileDrawer';
 import { MobilePanel } from './panel/MobilePanel';
 import { Modals } from './Modals';
 import { PageWrapper } from './PageWrapper';
-import { optimaActions, optimaOpenModels, optimaOpenPreferences } from './useOptima';
+import { optimaActions, optimaOpenModels, optimaOpenPreferences, optimaToggleDrawer, optimaTogglePanel } from './useOptima';
 
 
 // this undoes the PanelGroup styling on mobile, as it's not needed
@@ -80,6 +80,9 @@ export function OptimaLayout(props: { suspendAutoModelsSetup?: boolean, children
     // Shortcuts
     { key: Is.OS.MacOS ? '/' : '?', ctrl: true, shift: true, action: optimaActions().openKeyboardShortcuts },
     { key: 'h', ctrl: true, shift: true, action: '_specialPrintShortcuts' },
+    // Layout
+    { key: '(', ctrl: true, shift: true, action: () => optimaToggleDrawer() },
+    { key: ')', ctrl: true, shift: true, action: () => optimaTogglePanel() },
   ], []));
 
   return <>


### PR DESCRIPTION
Add keyboard shortcuts for toggling left drawer (Ctrl+() and right panel (Ctrl+)). Also adds a reusable `skipIfInput` flag for future shortcuts that conflict with text editing.

Closes #1013