### PR TITLE
Add Tensorix as a new LLM provider

### DIFF
--- a/src/modules/backend/backend.router.ts
+++ b/src/modules/backend/backend.router.ts
@@ -64,6 +64,7 @@ export const backendRouter = createTRPCRouter({
         hasLlmOpenPipe: !!env.OPENPIPE_API_KEY,
         hasLlmOpenRouter: !!env.OPENROUTER_API_KEY,
         hasLlmPerplexity: !!env.PERPLEXITY_API_KEY,
+        hasLlmTensorix: !!env.TENSORIX_API_KEY,
         hasLlmTogetherAI: !!env.TOGETHERAI_API_KEY,
         hasLlmXAI: !!env.XAI_API_KEY,
         // others

--- a/src/modules/backend/store-backend-capabilities.ts
+++ b/src/modules/backend/store-backend-capabilities.ts
@@ -24,6 +24,7 @@ export interface BackendCapabilities {
   hasLlmOpenPipe: boolean;
   hasLlmOpenRouter: boolean;
   hasLlmPerplexity: boolean;
+  hasLlmTensorix: boolean;
   hasLlmTogetherAI: boolean;
   hasLlmXAI: boolean;
   // others
@@ -66,6 +67,7 @@ const useBackendCapabilitiesStore = create<BackendStore>()(
     hasLlmOpenPipe: false,
     hasLlmOpenRouter: false,
     hasLlmPerplexity: false,
+    hasLlmTensorix: false,
     hasLlmTogetherAI: false,
     hasLlmXAI: false,
     hasDB: false,

--- a/src/modules/llms/components/LLMVendorSetup.tsx
+++ b/src/modules/llms/components/LLMVendorSetup.tsx
@@ -22,6 +22,7 @@ import { OpenAIServiceSetup } from '../vendors/openai/OpenAIServiceSetup';
 import { OpenPipeServiceSetup } from '../vendors/openpipe/OpenPipeServiceSetup';
 import { OpenRouterServiceSetup } from '../vendors/openrouter/OpenRouterServiceSetup';
 import { PerplexityServiceSetup } from '../vendors/perplexity/PerplexityServiceSetup';
+import { TensorixServiceSetup } from '../vendors/tensorix/TensorixServiceSetup';
 import { TogetherAIServiceSetup } from '../vendors/togetherai/TogetherAIServiceSetup';
 import { XAIServiceSetup } from '../vendors/xai/XAIServiceSetup';
 import { ZAIServiceSetup } from '~/modules/llms/vendors/zai/ZAIServiceSetup';
@@ -49,6 +50,7 @@ const vendorSetupComponents: Record<ModelVendorId, React.ComponentType<{ service
   openpipe: OpenPipeServiceSetup,
   openrouter: OpenRouterServiceSetup,
   perplexity: PerplexityServiceSetup,
+  tensorix: TensorixServiceSetup,
   togetherai: TogetherAIServiceSetup,
   xai: XAIServiceSetup,
   zai: ZAIServiceSetup,

--- a/src/modules/llms/server/openai/openai.access.ts
+++ b/src/modules/llms/server/openai/openai.access.ts
@@ -4,8 +4,8 @@
  * This module only imports zod for schema definition and provides access logic
  * that works identically on server and client environments.
  *
- * Supports 15 OpenAI-compatible dialects: alibaba, azure, deepseek, groq, lmstudio,
- * localai, mistral, moonshot, openai, openpipe, openrouter, perplexity, togetherai, xai, zai
+ * Supports 16 OpenAI-compatible dialects: alibaba, azure, deepseek, groq, lmstudio,
+ * localai, mistral, moonshot, openai, openpipe, openrouter, perplexity, tensorix, togetherai, xai, zai
  */
 
 import * as z from 'zod/v4';
@@ -31,6 +31,7 @@ const DEFAULT_OPENAI_HOST = 'api.openai.com';
 const DEFAULT_OPENPIPE_HOST = 'https://app.openpipe.ai/api';
 const DEFAULT_OPENROUTER_HOST = 'https://openrouter.ai/api';
 const DEFAULT_PERPLEXITY_HOST = 'https://api.perplexity.ai';
+const DEFAULT_TENSORIX_HOST = 'https://api.tensorix.ai';
 const DEFAULT_TOGETHERAI_HOST = 'https://api.together.xyz';
 const DEFAULT_XAI_HOST = 'https://api.x.ai';
 const DEFAULT_ZAI_HOST = 'https://api.z.ai/api/paas';
@@ -113,7 +114,7 @@ export const openAIAccessSchema = z.object({
   dialect: z.enum([
     'alibaba', 'azure', 'deepseek', 'groq', 'lmstudio',
     'localai', 'mistral', 'moonshot', 'openai', 'openpipe',
-    'openrouter', 'perplexity', 'togetherai', 'xai', 'zai',
+    'openrouter', 'perplexity', 'tensorix', 'togetherai', 'xai', 'zai',
   ]),
   clientSideFetch: z.boolean().optional(), // optional: backward compatibility from newer server version - can remove once all clients are updated
   oaiKey: z.string().trim(),
@@ -407,6 +408,23 @@ export function openAIAccess(access: OpenAIAccessSchema, modelRefId: string | nu
           'Authorization': `Bearer ${xaiKey}`,
         },
         url: DEFAULT_XAI_HOST + apiPath,
+      };
+
+    case 'tensorix':
+      // https://docs.tensorix.ai - OpenAI-compatible API
+      let tensorixKey = access.oaiKey || env.TENSORIX_API_KEY || '';
+      const tensorixHost = llmsFixupHost(access.oaiHost || DEFAULT_TENSORIX_HOST, apiPath);
+
+      tensorixKey = llmsRandomKeyFromMultiKey(tensorixKey);
+      if (!tensorixKey || !tensorixHost)
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Tensorix API Key or Host. Add it on the UI (Models Setup) or server side (your deployment).' });
+
+      return {
+        headers: {
+          'Authorization': `Bearer ${tensorixKey}`,
+          'Content-Type': 'application/json',
+        },
+        url: tensorixHost + apiPath,
       };
 
     case 'zai':

--- a/src/modules/llms/vendors/tensorix/TensorixServiceSetup.tsx
+++ b/src/modules/llms/vendors/tensorix/TensorixServiceSetup.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+
+import type { DModelsServiceId } from '~/common/stores/llms/llms.service.types';
+import { AlreadySet } from '~/common/components/AlreadySet';
+import { ExternalLink } from '~/common/components/ExternalLink';
+import { FormInputKey } from '~/common/components/forms/FormInputKey';
+import { FormTextField } from '~/common/components/forms/FormTextField';
+import { InlineError } from '~/common/components/InlineError';
+import { SetupFormClientSideToggle } from '~/common/components/forms/SetupFormClientSideToggle';
+import { SetupFormRefetchButton } from '~/common/components/forms/SetupFormRefetchButton';
+import { useToggleableBoolean } from '~/common/util/hooks/useToggleableBoolean';
+
+import { ApproximateCosts } from '../ApproximateCosts';
+import { useLlmUpdateModels } from '../../llm.client.hooks';
+import { useServiceSetup } from '../useServiceSetup';
+
+import { ModelVendorTensorix } from './tensorix.vendor';
+
+
+const TENSORIX_REG_LINK = 'https://app.tensorix.ai/dashboard';
+
+
+export function TensorixServiceSetup(props: { serviceId: DModelsServiceId }) {
+
+  // state
+  const advanced = useToggleableBoolean();
+
+  // external state
+  const {
+    service, serviceAccess, serviceHasCloudTenantConfig, serviceHasLLMs,
+    serviceSetupValid, updateSettings,
+  } = useServiceSetup(props.serviceId, ModelVendorTensorix);
+
+  // derived state
+  const { clientSideFetch, oaiKey: tensorixKey, oaiHost: tensorixHost } = serviceAccess;
+  const needsUserKey = !serviceHasCloudTenantConfig;
+  const showAdvanced = advanced.on || !!clientSideFetch || !!tensorixHost;
+
+  // validate if url is a well formed proper url with zod
+  const shallFetchSucceed = !needsUserKey || (!!tensorixKey && serviceSetupValid);
+  const showKeyError = !!tensorixKey && !serviceSetupValid;
+
+  // fetch models
+  const { isFetching, refetch, isError, error } =
+    useLlmUpdateModels(!serviceHasLLMs && shallFetchSucceed, service);
+
+
+  return <>
+
+    <ApproximateCosts serviceId={service?.id} />
+
+    <FormInputKey
+      autoCompleteId='tensorix-key' label='Tensorix API Key'
+      rightLabel={<>{needsUserKey
+        ? !tensorixKey && <ExternalLink level='body-sm' href={TENSORIX_REG_LINK}>get API Key</ExternalLink>
+        : <AlreadySet />}
+      </>}
+      value={tensorixKey} onChange={value => updateSettings({ tensorixKey: value })}
+      required={needsUserKey} isError={showKeyError}
+      placeholder='Your Tensorix API Key'
+    />
+
+    {showAdvanced && <FormTextField
+      autoCompleteId='tensorix-host'
+      title='API Host'
+      tooltip={`An alternative Tensorix API endpoint to use instead of the default 'api.tensorix.ai'.\n\nExample:\n - https://api.tensorix.ai`}
+      placeholder='e.g., https://api.tensorix.ai'
+      value={tensorixHost}
+      onChange={text => updateSettings({ tensorixHost: text })}
+    />}
+
+    {showAdvanced && <SetupFormClientSideToggle
+      visible={!!tensorixKey}
+      checked={!!clientSideFetch}
+      onChange={on => updateSettings({ csf: on })}
+      helpText='Connect directly to Tensorix API from your browser instead of through the server.'
+    />}
+
+    <SetupFormRefetchButton refetch={refetch} disabled={/*!shallFetchSucceed ||*/ isFetching} loading={isFetching} error={isError} advanced={advanced} />
+
+    {isError && <InlineError error={error} />}
+
+  </>;
+}

--- a/src/modules/llms/vendors/tensorix/tensorix.vendor.ts
+++ b/src/modules/llms/vendors/tensorix/tensorix.vendor.ts
@@ -1,0 +1,49 @@
+import type { IModelVendor } from '../IModelVendor';
+import type { OpenAIAccessSchema } from '../../server/openai/openai.access';
+
+import { ModelVendorOpenAI } from '../openai/openai.vendor';
+
+
+export interface DTensorixServiceSettings {
+  tensorixKey: string;
+  tensorixHost: string;
+  csf?: boolean;
+}
+
+export const ModelVendorTensorix: IModelVendor<DTensorixServiceSettings, OpenAIAccessSchema> = {
+  id: 'tensorix',
+  name: 'Tensorix',
+  displayRank: 18,
+  displayGroup: 'cloud',
+  location: 'cloud',
+  instanceLimit: 1,
+  hasServerConfigKey: 'hasLlmTensorix',
+
+  /// client-side-fetch ///
+  csfAvailable: _csfTensorixAvailable,
+
+  // functions
+  initializeSetup: () => ({
+    tensorixKey: '',
+    tensorixHost: '',
+  }),
+  validateSetup: (setup) => {
+    return setup.tensorixKey?.length >= 20;
+  },
+  getTransportAccess: (partialSetup) => ({
+    dialect: 'tensorix',
+    clientSideFetch: _csfTensorixAvailable(partialSetup) && !!partialSetup?.csf,
+    oaiKey: partialSetup?.tensorixKey || '',
+    oaiOrg: '',
+    oaiHost: partialSetup?.tensorixHost || '',
+    heliKey: '',
+  }),
+
+  // OpenAI transport ('tensorix' dialect in 'access')
+  rpcUpdateModelsOrThrow: ModelVendorOpenAI.rpcUpdateModelsOrThrow,
+
+};
+
+function _csfTensorixAvailable(s?: Partial<DTensorixServiceSettings>) {
+  return !!s?.tensorixKey;
+}

--- a/src/modules/llms/vendors/vendors.registry.ts
+++ b/src/modules/llms/vendors/vendors.registry.ts
@@ -16,6 +16,7 @@ import { ModelVendorOpenAI } from './openai/openai.vendor';
 import { ModelVendorOpenPipe } from './openpipe/openpipe.vendor';
 import { ModelVendorOpenRouter } from './openrouter/openrouter.vendor';
 import { ModelVendorPerplexity } from './perplexity/perplexity.vendor';
+import { ModelVendorTensorix } from './tensorix/tensorix.vendor';
 import { ModelVendorTogetherAI } from './togetherai/togetherai.vendor';
 import { ModelVendorXAI } from './xai/xai.vendor';
 import { ModelVendorZAI } from './zai/zai.vendor';
@@ -40,6 +41,7 @@ export type ModelVendorId =
   | 'openpipe'
   | 'openrouter'
   | 'perplexity'
+  | 'tensorix'
   | 'togetherai'
   | 'xai'
   | 'zai'
@@ -63,6 +65,7 @@ const MODEL_VENDOR_REGISTRY: Record<ModelVendorId, IModelVendor> = {
   openpipe: ModelVendorOpenPipe,
   openrouter: ModelVendorOpenRouter,
   perplexity: ModelVendorPerplexity,
+  tensorix: ModelVendorTensorix,
   togetherai: ModelVendorTogetherAI,
   xai: ModelVendorXAI,
   zai: ModelVendorZAI,

--- a/src/server/env.server.ts
+++ b/src/server/env.server.ts
@@ -91,6 +91,9 @@ export const env = createEnv({
     // LLM: Perplexity
     PERPLEXITY_API_KEY: z.string().optional(),
 
+    // LLM: Tensorix
+    TENSORIX_API_KEY: z.string().optional(),
+
     // LLM: Together AI
     TOGETHERAI_API_KEY: z.string().optional(),
 


### PR DESCRIPTION
Hey there 👋

This adds [Tensorix](https://tensorix.ai) as a new OpenAI-compatible vendor in big-AGI, letting users access models from DeepSeek, Meta Llama, Qwen, GLM, MiniMax and more through a single API key and endpoint.

Tensorix follows the same OpenAI-compatible pattern as Deepseek/Together/etc, so the integration is straightforward — new vendor folder + wiring into the existing dialect system.

### What's included

- **New vendor**: `src/modules/llms/vendors/tensorix/` — vendor definition + setup UI component
- **Dialect**: `tensorix` added to `openai.access.ts` with default host `https://api.tensorix.ai`
- **Server env**: `TENSORIX_API_KEY` for server-side deployment config
- **Backend capability**: `hasLlmTensorix` for the green checkmark when pre-configured
- **Registry + UI wiring**: vendor registered in `vendors.registry.ts`, `LLMVendorSetup.tsx`, and `backend.router.ts`

### How it works

Users add their Tensorix API key in Models → Add → Tensorix and models are fetched from the `/v1/models` endpoint. The setup UI includes an optional custom host field and client-side fetch toggle, matching the pattern of other cloud vendors.

This also opens up cross-promotion opportunities — we'd be happy to feature big-AGI prominently in Tensorix's integration docs at [docs.tensorix.ai](https://docs.tensorix.ai).

Happy to adjust anything if needed!