### PR TITLE
fix: use local time for flash backup export filename (#1037)

### DIFF
--- a/src/modules/trade/BackupRestore.tsx
+++ b/src/modules/trade/BackupRestore.tsx
@@ -17,6 +17,7 @@ import { downloadBlob } from '~/common/util/downloadUtils';
 
 import { tradeFileVariant } from './trade.client';
 import { capitalizeFirstLetter } from '~/common/util/textUtils';
+import { prettyTimestampForFilenames } from '~/common/util/timeUtils';
 
 
 // configuration
@@ -980,7 +981,7 @@ export function FlashBackup(props: {
     setErrorMessage(null);
     try {
       onStartedBackup?.();
-      const dateStr = new Date().toISOString().split('.')[0].replace('T', '-');
+      const dateStr = prettyTimestampForFilenames(false);
       const success = await saveFlashObjectOrThrow(
         'full',
         event.ctrlKey, // control forces a traditional browser download - default: fileSave


### PR DESCRIPTION
Closes #1037

## Summary

The "Save all settings and chats" (flash backup) export filename was using `new Date().toISOString()` which produces UTC/GMT time, while the other two export options ("Download or share this chat" and "Backup or transfer all chats") correctly use `prettyTimestampForFilenames(false)` which produces local time.

## Changes

- `src/modules/trade/BackupRestore.tsx`: Replaced inline `new Date().toISOString().split('.')[0].replace('T', '-')` with `prettyTimestampForFilenames(false)` and added the import

All three export filename paths now use the same utility, producing consistent local-time filenames.

## Test plan

- [ ] Export via "Download or share this chat" — filename uses local time
- [ ] Export via "Backup or transfer all chats" — filename uses local time
- [ ] Export via "Save all settings and chats" — filename now uses local time (was UTC before)
