### PR TITLE
Add 'New Chat on Startup' setting

### DIFF
--- a/src/apps/settings-modal/settings-ui/AppChatSettingsUI.tsx
+++ b/src/apps/settings-modal/settings-ui/AppChatSettingsUI.tsx
@@ -60,12 +60,14 @@ export function AppChatSettingsUI() {
     doubleClickToEdit, setDoubleClickToEdit,
     enterIsNewline, setEnterIsNewline,
     showPersonaFinder, setShowPersonaFinder,
+    startupNewChat, setStartupNewChat,
   } = useUIPreferencesStore(useShallow(state => ({
     centerMode: state.centerMode, setCenterMode: state.setCenterMode,
     disableMarkdown: state.disableMarkdown, setDisableMarkdown: state.setDisableMarkdown,
     doubleClickToEdit: state.doubleClickToEdit, setDoubleClickToEdit: state.setDoubleClickToEdit,
     enterIsNewline: state.enterIsNewline, setEnterIsNewline: state.setEnterIsNewline,
     showPersonaFinder: state.showPersonaFinder, setShowPersonaFinder: state.setShowPersonaFinder,
+    startupNewChat: state.startupNewChat, setStartupNewChat: state.setStartupNewChat,
   })));
 
   const handleEnterIsNewlineChange = (event: React.ChangeEvent<HTMLInputElement>) => setEnterIsNewline(!event.target.checked);
@@ -75,6 +77,8 @@ export function AppChatSettingsUI() {
   const handleDisableMarkdown = (event: React.ChangeEvent<HTMLInputElement>) => setDisableMarkdown(event.target.checked);
 
   const handleShowSearchBarChange = (event: React.ChangeEvent<HTMLInputElement>) => setShowPersonaFinder(event.target.checked);
+
+  const handleStartupNewChatChange = (event: React.ChangeEvent<HTMLInputElement>) => setStartupNewChat(event.target.checked);
 
   return <>
 
@@ -117,6 +121,14 @@ export function AppChatSettingsUI() {
               endDecorator={showPersonaFinder ? 'On' : 'Off'}
               slotProps={{ endDecorator: { sx: { minWidth: 26 } } }} />
     </FormControl>}
+
+    <FormControl orientation='horizontal' sx={{ justifyContent: 'space-between' }}>
+      <FormLabelStart title='New Chat on Startup'
+                      description={startupNewChat ? 'New empty chat' : 'Reopen last chat'} />
+      <Switch checked={startupNewChat} onChange={handleStartupNewChatChange}
+              endDecorator={startupNewChat ? 'On' : 'Off'}
+              slotProps={{ endDecorator: { sx: { minWidth: 26 } } }} />
+    </FormControl>
 
     <SettingUIContentScaling />
 

--- a/src/common/stores/chat/store-chats.ts
+++ b/src/common/stores/chat/store-chats.ts
@@ -8,6 +8,7 @@ import type { DLLMId } from '~/common/stores/llms/llms.types';
 import { findLLMOrThrow, getChatLLMId } from '~/common/stores/llms/store-llms';
 
 import { agiUuid } from '~/common/util/idUtils';
+import { useUIPreferencesStore } from '~/common/stores/store-ui';
 import { backupIdbV3, createIDBPersistStorage } from '~/common/util/idbUtils';
 
 import { workspaceActions } from '~/common/stores/workspace/store-client-workspace';
@@ -488,8 +489,12 @@ export const useChatStore = create<ConversationsStore>()(/*devtools(*/
         const mergedConversations = [...(currentState?.conversations || [])];
         if (persistedState && typeof persistedState === 'object' && 'conversations' in persistedState) {
           const storedConversations = persistedState.conversations as ChatState['conversations'];
-          if (storedConversations.length)
+          if (storedConversations.length) {
+            // [setting] skip the default new conversation if the user prefers to reopen the last chat
+            if (!useUIPreferencesStore.getState().startupNewChat)
+              mergedConversations.length = 0;
             mergedConversations.push(...storedConversations);
+          }
         }
 
         return {

--- a/src/common/stores/store-ui.ts
+++ b/src/common/stores/store-ui.ts
@@ -57,6 +57,9 @@ interface UIPreferencesStore {
   composerQuickButton: 'off' | 'call' | 'beam';
   setComposerQuickButton: (composerQuickButton: 'off' | 'call' | 'beam') => void;
 
+  startupNewChat: boolean;
+  setStartupNewChat: (startupNewChat: boolean) => void;
+
   // Advanced features
 
   aixInspector: boolean;
@@ -131,6 +134,9 @@ export const useUIPreferencesStore = create<UIPreferencesStore>()(
 
       composerQuickButton: 'beam',
       setComposerQuickButton: (composerQuickButton: 'off' | 'call' | 'beam') => set({ composerQuickButton }),
+
+      startupNewChat: true,
+      setStartupNewChat: (startupNewChat: boolean) => set({ startupNewChat }),
 
       // Advanced features
 


### PR DESCRIPTION
## Summary
- Adds a toggle in **Preferences > Chat** called "New Chat on Startup"
- When **On** (default): current behavior, creates a new empty chat on every page load
- When **Off**: reopens the last conversation instead of creating a new one

## Motivation
As discussed in Discord, users who prefer to continue their previous conversations find it inconvenient that a new empty chat is always created on startup. This setting gives users control over that behavior while preserving the current default.

## Changes
- `src/common/stores/store-ui.ts` - New `startupNewChat` boolean property (default `true`)
- `src/apps/settings-modal/settings-ui/AppChatSettingsUI.tsx` - Switch toggle in Chat settings
- `src/common/stores/chat/store-chats.ts` - Conditional in `merge()` to skip default empty conversation

Minimal change (3 files, ~20 lines), reuses existing patterns, no new utilities or migrations.

## Test plan
- [x] Open app with setting On (default) - new empty chat created as usual
- [x] Turn setting Off, reload - last conversation reopens
- [x] Turn setting back On, reload - new empty chat again
- [x] TypeScript and ESLint pass clean