### PR TITLE
store-chats: bump updated timestamp in title and symbol mutations

### DIFF
--- a/src/common/stores/chat/store-chats.ts
+++ b/src/common/stores/chat/store-chats.ts
@@ -419,6 +419,7 @@ export const useChatStore = create<ConversationsStore>()(/*devtools(*/
         _get()._editConversation(conversationId,
           {
             autoTitle,
+            updated: Date.now(),
           }),
 
       setUserTitle: (conversationId: DConversationId, userTitle: string) =>
@@ -426,6 +427,7 @@ export const useChatStore = create<ConversationsStore>()(/*devtools(*/
           {
             userTitle,
             ...(!userTitle && { autoTitle: undefined }), // clear autotitle when clearing usertitle
+            updated: Date.now(),
           }),
 
       title: (conversationId: DConversationId): string | undefined => {
@@ -437,6 +439,7 @@ export const useChatStore = create<ConversationsStore>()(/*devtools(*/
         _get()._editConversation(conversationId,
           {
             userSymbol: userSymbol || undefined,
+            updated: Date.now(),
           }),
 
       setArchived: (conversationId: DConversationId, isArchived: boolean) =>


### PR DESCRIPTION
## Summary

`setAutoTitle`, `setUserTitle`, and `setUserSymbol` mutate conversation metadata but do not update the conversation's `updated` timestamp. This means conversations sorted by last-modified time can appear out of order after a rename or symbol change.

## What Changed

Added `updated: Date.now()` to three reducers in `store-chats.ts`:

- `setAutoTitle` - called when the AI generates a title after the first exchange
- `setUserTitle` - called when the user renames a conversation
- `setUserSymbol` - called when the user sets an emoji/symbol on a conversation

This aligns them with the pattern already used by all other conversation mutation actions (`appendMessage`, `deleteMessage`, `historyReplace`, `editMessage`, etc.).

`setArchived` is intentionally left unchanged - it has an explicit comment in the code noting that archiving should not update the modified time.

## Test plan

- [ ] Rename a conversation via the title field - verify `updated` is bumped (visible via sorted conversation list moving to top)
- [ ] Set a symbol on a conversation - verify `updated` is bumped
- [ ] Wait for auto-title to be generated on a new chat - verify `updated` is bumped
- [ ] `tsc --noEmit --pretty && npm run lint` passes

Closes #1102