### PR TITLE
Chat: Liquid Matrix multi-agent execute mode

### DIFF
--- a/src/apps/chat/components/message/fragments-content/BlockPartText_AutoBlocks.tsx
+++ b/src/apps/chat/components/message/fragments-content/BlockPartText_AutoBlocks.tsx
@@ -9,6 +9,8 @@ import type { DMessageRole } from '~/common/stores/chat/chat.message';
 import { GoodTooltip } from '~/common/components/GoodTooltip';
 import { InlineError } from '~/common/components/InlineError';
 
+import { isSLMOutput, SLMOutputRenderer } from '~/modules/slm/SLMOutputRenderer';
+
 import { explainServiceErrors } from '../explainServiceErrors';
 
 /**
@@ -56,6 +58,10 @@ export function BlockPartText_AutoBlocks(props: {
     () => !messageText ? null : explainServiceErrors(messageText, fromAssistant),
     [fromAssistant, messageText],
   );
+
+  // SLM pipeline output: render with collapsible phase accordion UI
+  if (fromAssistant && isSLMOutput(messageText))
+    return <SLMOutputRenderer text={messageText} />;
 
   // if errored, render an Auto-Error message
   if (errorExplainer) {

--- a/src/apps/chat/editors/_handleExecute.ts
+++ b/src/apps/chat/editors/_handleExecute.ts
@@ -14,6 +14,7 @@ import { _handleExecuteCommand, RET_NO_CMD } from './_handleExecuteCommand';
 import { runImageGenerationUpdatingState } from './image-generate';
 import { runPersonaOnConversationHead } from './chat-persona';
 import { runReActUpdatingState } from './react-tangent';
+import { runSLMUpdatingState } from './slm-tangent';
 
 
 export async function _handleExecute(chatExecuteMode: ChatExecuteMode, conversationId: DConversationId, executeCallerNameDebug: string) {
@@ -101,6 +102,9 @@ export async function _handleExecute(chatExecuteMode: ChatExecuteMode, conversat
       const reactPrompt = firstFragment.part.text;
       cHandler.messageFragmentReplace(lastMessage.id, firstFragment.fId, createTextContentFragment(`/react ${reactPrompt}`), true);
       return await runReActUpdatingState(cHandler, reactPrompt, chatLLMId, lastMessage.id);
+
+    case 'slm-content':
+      return await runSLMUpdatingState(cHandler, initialHistory, chatLLMId);
 
     default:
       console.log('Chat execute: issue running', chatExecuteMode, conversationId, lastMessage);

--- a/src/apps/chat/editors/chat-persona.ts
+++ b/src/apps/chat/editors/chat-persona.ts
@@ -2,12 +2,16 @@ import { aixChatGenerateContent_DMessage_FromConversation, AixChatGenerateConten
 import { autoChatFollowUps } from '~/modules/aifn/auto-chat-follow-ups/autoChatFollowUps';
 import { autoConversationTitle } from '~/modules/aifn/autotitle/autoTitle';
 
+import { createTextContentFragment } from '~/common/stores/chat/chat.fragments';
+
 import { DConversationId, splitSystemMessageFromHistory } from '~/common/stores/chat/chat.conversation';
 import type { DLLMId } from '~/common/stores/llms/llms.types';
 import { AudioGenerator } from '~/common/util/audio/AudioGenerator';
 import { ConversationsManager } from '~/common/chat-overlay/ConversationsManager';
 import { DMessage, MESSAGE_FLAG_NOTIFY_COMPLETE, messageWasInterruptedAtStart } from '~/common/stores/chat/chat.message';
 import { getLabsHighPerformance } from '~/common/stores/store-ux-labs';
+
+import { runSLMPipeline, extractLastUserMessageText, buildConversationContext } from '~/modules/slm/slm.pipeline';
 
 import { PersonaChatMessageSpeak } from './persona/PersonaChatMessageSpeak';
 import { getChatAutoAI, getChatThinkingPolicy, getIsNotificationEnabledForModel } from '../store-app-chat';
@@ -63,6 +67,41 @@ export async function runPersonaOnConversationHead(
   // when an abort controller is set, the UI switches to the "stop" mode
   const abortController = new AbortController();
   cHandler.setAbortController(abortController, 'chat-persona');
+
+  // SLM Orchestrator: intercept and run the full multi-agent pipeline
+  if (chatSystemInstruction?.purposeId === 'SLMOrchestrator') {
+    try {
+      const userMessage = extractLastUserMessageText(chatHistory);
+      const conversationContext = buildConversationContext(chatHistory);
+
+      await runSLMPipeline({
+        userMessage,
+        conversationContext,
+        llmId: assistantLlmId,
+        abortSignal: abortController.signal,
+        onProgress: (progressText: string, done: boolean) => {
+          const progressMessage: AixChatGenerateContent_DMessageGuts = {
+            fragments: [createTextContentFragment(progressText)],
+            generator: { mgt: 'named', name: assistantLlmId },
+            pendingIncomplete: !done,
+          };
+          cHandler.messageEdit(assistantMessageId, progressMessage, done, false);
+        },
+      });
+    } catch (err: any) {
+      const errText = `**SLM Pipeline Error**\n\n${err?.message ?? 'Unknown error'}\n\nFalling back to standard mode.`;
+      const errMessage: AixChatGenerateContent_DMessageGuts = {
+        fragments: [createTextContentFragment(errText)],
+        generator: { mgt: 'named', name: assistantLlmId },
+        pendingIncomplete: false,
+      };
+      cHandler.messageEdit(assistantMessageId, errMessage, true, false);
+    }
+
+    cHandler.clearAbortController('chat-persona');
+    if (autoTitleChat) void autoConversationTitle(conversationId, false);
+    return !abortController.signal.aborted;
+  }
 
   // stream the assistant's messages directly to the state store
   const messageStatus = await aixChatGenerateContent_DMessage_FromConversation(

--- a/src/apps/chat/editors/slm-tangent.ts
+++ b/src/apps/chat/editors/slm-tangent.ts
@@ -1,0 +1,69 @@
+import type { ConversationHandler } from '~/common/chat-overlay/ConversationHandler';
+import type { DLLMId } from '~/common/stores/llms/llms.types';
+import type { DMessage } from '~/common/stores/chat/chat.message';
+import type { DMessageFragmentId } from '~/common/stores/chat/chat.fragments';
+import { createErrorContentFragment, createTextContentFragment, isTextContentFragment } from '~/common/stores/chat/chat.fragments';
+
+import { buildConversationContext, extractLastUserMessageText, runSLMPipeline } from '~/modules/slm/slm.pipeline';
+
+
+export async function runSLMUpdatingState(cHandler: ConversationHandler, history: Readonly<DMessage[]>, assistantLlmId: DLLMId) {
+  const userMessage = extractLastUserMessageText(history);
+  if (!userMessage) {
+    cHandler.messageAppendAssistantText('Issue: no message provided.', 'issue');
+    return false;
+  }
+
+  const { assistantMessageId, placeholderFragmentId } = cHandler.messageAppendAssistantPlaceholder(
+    '⚡ Liquid Matrix initializing...',
+    { generator: { mgt: 'named', name: 'slm-' + assistantLlmId } },
+  );
+
+  const abortController = new AbortController();
+  cHandler.setAbortController(abortController, 'slm-tangent');
+
+  // The placeholder is a void fragment - track the real text fragment fId after first replace
+  let textFragmentId: DMessageFragmentId = placeholderFragmentId;
+  let hasTextFragment = false;
+
+  const setFragmentText = (text: string, complete: boolean) => {
+    if (!hasTextFragment) {
+      // Swap void placeholder for a real text content fragment, track the new fId
+      const newFrag = createTextContentFragment(text);
+      cHandler.messageFragmentReplace(assistantMessageId, textFragmentId, newFrag, complete);
+      textFragmentId = newFrag.fId;
+      hasTextFragment = true;
+    } else {
+      // Update the existing text fragment in-place (same fId - no remount)
+      cHandler.messageEdit(assistantMessageId, (message) => {
+        const idx = message.fragments.findIndex(f => f.fId === textFragmentId);
+        if (idx < 0) return {};
+        const frag = message.fragments[idx];
+        if (!isTextContentFragment(frag)) return {};
+        return {
+          fragments: message.fragments.map((f, i) =>
+            i === idx ? { ...frag, part: { ...frag.part, text } } : f,
+          ),
+        };
+      }, complete, false);
+    }
+  };
+
+  try {
+    await runSLMPipeline({
+      userMessage,
+      conversationContext: buildConversationContext(history),
+      llmId: assistantLlmId,
+      abortSignal: abortController.signal,
+      onProgress: setFragmentText,
+    });
+
+    return true;
+  } catch (error: any) {
+    const msg = `**SLM Pipeline Error**\n\n${error?.message ?? 'Unknown error'}`;
+    cHandler.messageFragmentReplace(assistantMessageId, textFragmentId, createErrorContentFragment(msg), true);
+    return false;
+  } finally {
+    cHandler.clearAbortController('slm-tangent');
+  }
+}

--- a/src/apps/chat/execute-mode/execute-mode.items.ts
+++ b/src/apps/chat/execute-mode/execute-mode.items.ts
@@ -59,4 +59,10 @@ export const ExecuteModeItems: { [key in ChatExecuteMode]: ModeDescription } = {
     sendColor: 'success',
     sendText: 'ReAct',
   },
+  'slm-content': {
+    label: 'Liquid Matrix',
+    description: 'Multi-agent orchestration - routes to specialist agents automatically',
+    sendColor: 'neutral',
+    sendText: 'Matrix',
+  },
 };

--- a/src/apps/chat/execute-mode/execute-mode.types.ts
+++ b/src/apps/chat/execute-mode/execute-mode.types.ts
@@ -8,4 +8,5 @@ export type ChatExecuteMode =
   | 'generate-content'
   | 'generate-image'
   | 'react-content'
+  | 'slm-content'
   ;

--- a/src/common/components/icons/vendors/SlmIcon.tsx
+++ b/src/common/components/icons/vendors/SlmIcon.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import SvgIcon, { SvgIconProps } from '@mui/joy/SvgIcon';
+
+export function SlmIcon(props: SvgIconProps) {
+  return (
+    <SvgIcon viewBox="0 0 24 24" width="24" height="24" {...props}>
+      <path
+        d="M12 2L2 7l10 5 10-5-10-5zm0 7.5L4.5 7 12 3.25 19.5 7 12 9.5zM2 17l10 5 10-5M2 12l10 5 10-5"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </SvgIcon>
+  );
+}

--- a/src/modules/slm/SLMOutputRenderer.tsx
+++ b/src/modules/slm/SLMOutputRenderer.tsx
@@ -22,7 +22,8 @@ import { RenderMarkdownMemo } from '~/modules/blocks/markdown/RenderMarkdown';
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface SLMPhase {
-  num: number;
+  id: string;        // e.g. "1", "1.5", "5b", "6b"
+  num: number;       // parseFloat(id) - for color lookup only
   name: string;
   content: string;
   hasWarning: boolean;
@@ -39,19 +40,21 @@ interface ParsedSLMOutput {
 // ─── Parser ───────────────────────────────────────────────────────────────────
 
 function parseSLMOutput(text: string): ParsedSLMOutput {
-  const phaseRegex = /\*\*Phase (\d+(?:\.\d+)?) — ([^\n*]+)\*\*/g;
+  // Matches "1", "1.5", "5b", "6b" etc.
+  const phaseRegex = /\*\*Phase (\d+(?:[.]\d+|[a-z])?) — ([^\n*]+)\*\*/g;
   const finalMarker = '## ✦ Final Output';
 
-  const phaseHits: Array<{ index: number; num: number; name: string }> = [];
+  const phaseHits: Array<{ index: number; id: string; num: number; name: string }> = [];
   let m: RegExpExecArray | null;
   while ((m = phaseRegex.exec(text)) !== null) {
-    phaseHits.push({ index: m.index, num: parseFloat(m[1]), name: m[2].trim() });
+    const id = m[1];
+    phaseHits.push({ index: m.index, id, num: parseFloat(id), name: m[2].trim() });
   }
 
   const finalIdx = text.indexOf(finalMarker);
   const isComplete = finalIdx !== -1;
 
-  const phases: SLMPhase[] = phaseHits.map(({ index, num, name }, i) => {
+  const phases: SLMPhase[] = phaseHits.map(({ index, id, num, name }, i) => {
     const lineEnd = text.indexOf('\n', index);
     const contentStart = lineEnd > -1 ? lineEnd + 1 : index;
     const nextBoundary =
@@ -61,6 +64,7 @@ function parseSLMOutput(text: string): ParsedSLMOutput {
     const isLast = i === phaseHits.length - 1;
 
     return {
+      id,
       num,
       name,
       content,
@@ -119,12 +123,12 @@ function PhaseStatus({ hasWarning, isActive }: { hasWarning: boolean; isActive: 
 function PhaseAccordion({ phase, isOpen, onToggle }: {
   phase: SLMPhase;
   isOpen: boolean;
-  onToggle: (num: number) => void;
+  onToggle: (id: string) => void;
 }) {
   const color = phaseColor(phase.num);
   const handleChange = React.useCallback(
-    (_e: React.SyntheticEvent, expanded: boolean) => { void expanded; onToggle(phase.num); },
-    [onToggle, phase.num],
+    (_e: React.SyntheticEvent, expanded: boolean) => { void expanded; onToggle(phase.id); },
+    [onToggle, phase.id],
   );
 
   return (
@@ -161,7 +165,7 @@ function PhaseAccordion({ phase, isOpen, onToggle }: {
             color={color}
             sx={{ fontFamily: 'code', fontSize: '0.65rem', fontWeight: 700, flexShrink: 0, letterSpacing: '0.03em' }}
           >
-            {Number.isInteger(phase.num) ? `P${phase.num}` : `P${phase.num}`}
+            {`P${phase.id}`}
           </Chip>
           <Typography
             level='body-sm'
@@ -205,12 +209,12 @@ export function SLMOutputRenderer({ text }: { text: string }) {
   const { phases, finalOutput, isComplete } = React.useMemo(() => parseSLMOutput(text), [text]);
 
   // Open/close state lives here so streaming re-renders don't reset expand choices
-  const [openPhases, setOpenPhases] = React.useState<Set<number>>(new Set());
+  const [openPhases, setOpenPhases] = React.useState<Set<string>>(new Set());
 
-  const handleToggle = React.useCallback((num: number) => {
+  const handleToggle = React.useCallback((id: string) => {
     setOpenPhases(prev => {
       const next = new Set(prev);
-      if (next.has(num)) next.delete(num); else next.add(num);
+      if (next.has(id)) next.delete(id); else next.add(id);
       return next;
     });
   }, []);
@@ -255,9 +259,9 @@ export function SLMOutputRenderer({ text }: { text: string }) {
         <AccordionGroup disableDivider sx={{ gap: 0 }}>
           {phases.map(phase => (
             <PhaseAccordion
-              key={phase.num}
+              key={phase.id}
               phase={phase}
-              isOpen={openPhases.has(phase.num)}
+              isOpen={openPhases.has(phase.id)}
               onToggle={handleToggle}
             />
           ))}

--- a/src/modules/slm/SLMOutputRenderer.tsx
+++ b/src/modules/slm/SLMOutputRenderer.tsx
@@ -1,0 +1,308 @@
+import * as React from 'react';
+
+import type { ColorPaletteProp, SxProps } from '@mui/joy/styles/types';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionGroup,
+  AccordionSummary,
+  Box,
+  Chip,
+  Divider,
+  Typography,
+} from '@mui/joy';
+import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
+import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
+import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded';
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
+
+import { RenderMarkdownMemo } from '~/modules/blocks/markdown/RenderMarkdown';
+
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface SLMPhase {
+  num: number;
+  name: string;
+  content: string;
+  hasWarning: boolean;
+  isActive: boolean; // currently running (not yet complete)
+}
+
+interface ParsedSLMOutput {
+  phases: SLMPhase[];
+  finalOutput: string | null;
+  isComplete: boolean;
+}
+
+
+// ─── Parser ───────────────────────────────────────────────────────────────────
+
+function parseSLMOutput(text: string): ParsedSLMOutput {
+  const phaseRegex = /\*\*Phase (\d+(?:\.\d+)?) — ([^\n*]+)\*\*/g;
+  const finalMarker = '## ✦ Final Output';
+
+  const phaseHits: Array<{ index: number; num: number; name: string }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = phaseRegex.exec(text)) !== null) {
+    phaseHits.push({ index: m.index, num: parseFloat(m[1]), name: m[2].trim() });
+  }
+
+  const finalIdx = text.indexOf(finalMarker);
+  const isComplete = finalIdx !== -1;
+
+  const phases: SLMPhase[] = phaseHits.map(({ index, num, name }, i) => {
+    const lineEnd = text.indexOf('\n', index);
+    const contentStart = lineEnd > -1 ? lineEnd + 1 : index;
+    const nextBoundary =
+      phaseHits[i + 1]?.index ??
+      (isComplete ? Math.max(0, text.lastIndexOf('\n---', finalIdx)) : text.length);
+    const content = text.slice(contentStart, nextBoundary).trim();
+    const isLast = i === phaseHits.length - 1;
+
+    return {
+      num,
+      name,
+      content,
+      hasWarning: content.includes('⚠️'),
+      isActive: isLast && !isComplete,
+    };
+  });
+
+  let finalOutput: string | null = null;
+  if (isComplete) {
+    finalOutput = text.slice(finalIdx + finalMarker.length).trim();
+  }
+
+  return { phases, finalOutput, isComplete };
+}
+
+
+// ─── Phase color/label helpers ────────────────────────────────────────────────
+
+const PHASE_COLOR: Record<number, ColorPaletteProp> = {
+  1: 'neutral', 2: 'primary', 3: 'neutral', 4: 'warning',
+  5: 'success', 6: 'primary', 7: 'success',
+};
+
+function phaseColor(num: number): ColorPaletteProp {
+  return PHASE_COLOR[Math.floor(num)] ?? 'neutral';
+}
+
+
+// ─── Status indicator ─────────────────────────────────────────────────────────
+
+const spinSx: SxProps = {
+  display: 'inline-flex',
+  animation: 'slm-spin 1.1s linear infinite',
+  '@keyframes slm-spin': {
+    from: { transform: 'rotate(0deg)' },
+    to: { transform: 'rotate(360deg)' },
+  },
+};
+
+function PhaseStatus({ hasWarning, isActive }: { hasWarning: boolean; isActive: boolean }) {
+  if (isActive)
+    return (
+      <Box component='span' sx={{ ...spinSx, color: 'primary.400', fontSize: '1rem', lineHeight: 1 }}>
+        ◌
+      </Box>
+    );
+  if (hasWarning)
+    return <WarningAmberRoundedIcon sx={{ fontSize: '0.95rem', color: 'warning.500' }} />;
+  return <CheckRoundedIcon sx={{ fontSize: '0.95rem', color: 'success.500' }} />;
+}
+
+
+// ─── Single phase accordion ───────────────────────────────────────────────────
+
+function PhaseAccordion({ phase, isOpen, onToggle }: {
+  phase: SLMPhase;
+  isOpen: boolean;
+  onToggle: (num: number) => void;
+}) {
+  const color = phaseColor(phase.num);
+  const handleChange = React.useCallback(
+    (_e: React.SyntheticEvent, expanded: boolean) => { void expanded; onToggle(phase.num); },
+    [onToggle, phase.num],
+  );
+
+  return (
+    <Accordion
+      expanded={isOpen}
+      onChange={handleChange}
+      sx={{
+        border: '1px solid',
+        borderColor: isOpen ? `${color}.outlinedBorder` : 'divider',
+        borderRadius: 'sm',
+        mb: 0.5,
+        transition: 'border-color 0.15s',
+        '&:hover': { borderColor: `${color}.outlinedBorder` },
+        '&::before': { display: 'none' }, // remove default MUI divider line
+      }}
+    >
+      <AccordionSummary
+        indicator={<ExpandMoreRoundedIcon sx={{ fontSize: '1rem', opacity: 0.6 }} />}
+        slotProps={{
+          button: {
+            sx: {
+              py: 0.75, px: 1.25,
+              borderRadius: 'sm',
+              gap: 0.75,
+              '&[aria-expanded="true"]': { bgcolor: `${color}.softBg` },
+            },
+          },
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flex: 1, minWidth: 0 }}>
+          <Chip
+            size='sm'
+            variant='soft'
+            color={color}
+            sx={{ fontFamily: 'code', fontSize: '0.65rem', fontWeight: 700, flexShrink: 0, letterSpacing: '0.03em' }}
+          >
+            {Number.isInteger(phase.num) ? `P${phase.num}` : `P${phase.num}`}
+          </Chip>
+          <Typography
+            level='body-sm'
+            fontWeight='md'
+            sx={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'text.primary' }}
+          >
+            {phase.name}
+          </Typography>
+          <Box sx={{ flexShrink: 0, display: 'flex', alignItems: 'center', mr: 0.5 }}>
+            <PhaseStatus hasWarning={phase.hasWarning} isActive={phase.isActive} />
+          </Box>
+        </Box>
+      </AccordionSummary>
+
+      <AccordionDetails slotProps={{ content: { sx: { pb: 0 } } }}>
+        <Box sx={{ px: 1.5, pb: 1.5, pt: 0.5, maxHeight: 520, overflowY: 'auto', overflowX: 'hidden' }}>
+          {phase.content
+            ? <RenderMarkdownMemo content={phase.content} />
+            : (
+              <Typography level='body-xs' sx={{ color: 'text.tertiary', fontStyle: 'italic', py: 1 }}>
+                {phase.isActive ? 'Running…' : 'No content.'}
+              </Typography>
+            )
+          }
+        </Box>
+      </AccordionDetails>
+    </Accordion>
+  );
+}
+
+
+// ─── Main renderer ────────────────────────────────────────────────────────────
+
+const SLM_MARKER = '🛰️ **SLM Matrix Active**';
+
+export function isSLMOutput(text: string): boolean {
+  return text.trimStart().startsWith(SLM_MARKER);
+}
+
+export function SLMOutputRenderer({ text }: { text: string }) {
+  const { phases, finalOutput, isComplete } = React.useMemo(() => parseSLMOutput(text), [text]);
+
+  // Open/close state lives here so streaming re-renders don't reset expand choices
+  const [openPhases, setOpenPhases] = React.useState<Set<number>>(new Set());
+
+  const handleToggle = React.useCallback((num: number) => {
+    setOpenPhases(prev => {
+      const next = new Set(prev);
+      if (next.has(num)) next.delete(num); else next.add(num);
+      return next;
+    });
+  }, []);
+
+  const doneCount = phases.filter(p => !p.isActive).length;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, my: 0.5 }}>
+
+      {/* Header row */}
+      <Box sx={{
+        display: 'flex', alignItems: 'center', gap: 1,
+        px: 1.25, py: 0.65,
+        borderRadius: 'sm',
+        border: '1px solid',
+        borderColor: 'divider',
+        bgcolor: 'background.level1',
+      }}>
+        <AccountTreeOutlinedIcon sx={{ fontSize: '0.95rem', color: 'text.tertiary', flexShrink: 0 }} />
+        <Typography level='body-sm' fontWeight='lg' sx={{ letterSpacing: '0.01em', color: 'text.secondary' }}>
+          Liquid Matrix
+        </Typography>
+        {phases.length > 0 && (
+          <Chip size='sm' variant='outlined' color='neutral' sx={{ fontFamily: 'code', fontSize: '0.62rem', ml: 0.25 }}>
+            {doneCount}/{phases.length}
+          </Chip>
+        )}
+        {isComplete && (
+          <Chip size='sm' variant='soft' color='success' sx={{ ml: 'auto', fontSize: '0.65rem', fontWeight: 700 }}>
+            Complete
+          </Chip>
+        )}
+        {!isComplete && phases.length > 0 && (
+          <Chip size='sm' variant='soft' color='primary' sx={{ ml: 'auto', fontSize: '0.65rem' }}>
+            Running
+          </Chip>
+        )}
+      </Box>
+
+      {/* Phase accordions */}
+      {phases.length > 0 && (
+        <AccordionGroup disableDivider sx={{ gap: 0 }}>
+          {phases.map(phase => (
+            <PhaseAccordion
+              key={phase.num}
+              phase={phase}
+              isOpen={openPhases.has(phase.num)}
+              onToggle={handleToggle}
+            />
+          ))}
+        </AccordionGroup>
+      )}
+
+      {/* Final output — shown when pipeline completes */}
+      {finalOutput !== null && (
+        <Box sx={{
+          borderRadius: 'sm',
+          border: '1.5px solid',
+          borderColor: 'success.outlinedBorder',
+          overflow: 'hidden',
+        }}>
+          <Box sx={{
+            px: 1.25, py: 0.65,
+            bgcolor: 'success.softBg',
+            borderBottom: '1px solid',
+            borderColor: 'success.outlinedBorder',
+            display: 'flex', alignItems: 'center', gap: 0.75,
+          }}>
+            <CheckRoundedIcon sx={{ fontSize: '0.95rem', color: 'success.600' }} />
+            <Typography level='body-sm' fontWeight='lg' sx={{ color: 'success.700' }}>
+              Final Output
+            </Typography>
+          </Box>
+          <Box sx={{ px: 0.5 }}>
+            {finalOutput
+              ? <RenderMarkdownMemo content={finalOutput} />
+              : <Typography level='body-xs' sx={{ px: 2, py: 1, color: 'text.tertiary', fontStyle: 'italic' }}>Assembling…</Typography>
+            }
+          </Box>
+        </Box>
+      )}
+
+      {/* Empty state while waiting for first phase */}
+      {phases.length === 0 && !finalOutput && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1, py: 0.5 }}>
+          <Box component='span' sx={{ ...spinSx, color: 'primary.400', fontSize: '1rem' }}>◌</Box>
+          <Typography level='body-xs' sx={{ color: 'text.tertiary', fontStyle: 'italic' }}>
+            Initializing pipeline…
+          </Typography>
+        </Box>
+      )}
+
+    </Box>
+  );
+}

--- a/src/modules/slm/slm.agents.ts
+++ b/src/modules/slm/slm.agents.ts
@@ -149,43 +149,37 @@ export const SLM_AGENTS: Record<string, SLMAgent> = Object.fromEntries(
 );
 
 export function buildAgentSystemPrompt(agent: SLMAgent): string {
-  return `You are ${agent.name} (Node ${agent.id}), an expert specialist in the Sovereign Liquid Matrix (SLM-v3).
+  return `You are ${agent.name} (Node ${agent.id}), a world-class specialist in the Sovereign Liquid Matrix.
 
-Cluster: ${agent.cluster}
 Domain: ${agent.specialization}
-Brilliance: ${agent.brilliance}
 
-## ELITE QUALITY MANDATE — Non-Negotiable
-Your output will be cross-examined by specialist reviewers, a security validator, and a final synthesis agent before reaching the user. The assembled response goes directly to a senior engineer using it in production. There is no reviewer to catch what you miss — you are the expert.
+## Your Standard of Work
+You are the foremost expert in your domain. Write as that expert. Your contribution feeds a final synthesis that goes directly to a senior engineer or professional — incomplete, shallow, or hedged output fails them.
 
-Standards enforced at every output, without exception:
-- Every code block must execute without modification. Mentally run it line by line before submitting. If an import might be missing, add it. If a variable might be undefined, handle it.
-- Every performance, compatibility, or behavior claim must be precise and defensible. Do not assert things you are not certain of.
-- If web research context is provided in the user prompt, you MUST use it. Do not rely on potentially stale training knowledge when authoritative current documentation is available.
-- If you cannot produce expert-tier output for a required section, state exactly what is needed and why rather than producing filler. A clear gap statement is better than a confident wrong answer.
-- Surface-level or partial responses will be flagged by reviewers and sent back for complete revision. Depth is required, not optional.
+**Depth floor — your response must:**
+- Address every dimension of the task, not just the obvious surface
+- Include all code, configuration, commands, and explanations needed to act immediately
+- Show the WHY behind key decisions, not just the WHAT
+- Cover the realistic failure modes, edge cases, and gotchas in your domain
+- Be long enough to be genuinely complete — a thorough expert answer, not a summary
 
-## Operational Directives
-1. Stay strictly within your domain. Do not produce output outside your specialization.
-2. Deliver production-ready work — actual runnable code, real configurations, concrete decisions. Never pseudocode, never vague suggestions without a concrete implementation.
-3. If the user specifies a programming language or technology, use EXACTLY that. Do not substitute an alternative. A Python request gets Python. A Go request gets Go. No exceptions.
-4. Apply best practices without being prompted:
-   - Escape all user-controlled data inserted into HTML, SQL, or shell commands
-   - Handle all realistic failure modes (null/None, network timeouts, empty inputs, malformed data)
-   - Never hardcode credentials, tokens, or secrets — use environment variables or config injection
-   - Use idiomatic, production-grade patterns for the target language and framework
-5. Self-review before submitting: mentally execute your code, check imports exist, verify logic is sound, catch security holes, confirm all requested features are implemented.
-6. Be maximally concrete: name the specific library version, write the actual regex, show the exact config value. Vague guidance is worse than silence.
-7. ARCHITECTURE MANDATE — Never collapse structure for brevity. This is a hard rule:
-   - If the system has natural module boundaries (config, database, auth, services, API routes, models), deliver EACH as a separate, fully-written file with its correct path as a header comment.
-   - Example: a FastAPI project must have separate files for main.py, config.py, database.py, models.py, each service, each router — never merged into one file.
-   - Consolidating multiple modules into a single file to save space is automatic review failure. Reviewers are explicitly instructed to hard-fail architecture collapse.
-   - Every file must be complete and self-contained — no "...rest of file..." ellipsis, no truncation, no "add your logic here" stubs.
+**Code and technical output rules:**
+- Every code block runs exactly as written. Mentally execute it line by line. Fix any missing imports, undefined variables, or broken logic before submitting.
+- No pseudocode, no stubs, no "add your logic here". Real implementation only.
+- If the task has multiple files/modules, deliver each as a complete separate file with its full path as a header comment.
+- Never truncate — if a file is too long to fit, you still write all of it.
+- Language: if the user specifies one, use EXACTLY that language. No substitutions.
 
-## Response Format
+**Quality checks before you submit:**
+- Does my output fully address every part of the task? If not, write more.
+- Is every code block complete and runnable without modifications?
+- Would a senior engineer reading this have everything they need, or would they need to ask follow-up questions? If the latter, add the missing pieces.
+- Have I explained the non-obvious parts?
+
+## Format
 - Open with: [${agent.id} · ${agent.name}]
-- Deliver your complete, self-contained work
-- Close with: **Confidence:** [0.00–1.00] | **Coverage:** [what you fully addressed] | **Gaps:** [out-of-scope items or known limitations]`;
+- Write your complete contribution with clear headings
+- Close with: **Confidence:** [0.00–1.00] | **Covered:** [brief list] | **Out of scope:** [what you intentionally left to other agents]`;
 }
 
 export function buildOrchestratorRoster(): string {

--- a/src/modules/slm/slm.agents.ts
+++ b/src/modules/slm/slm.agents.ts
@@ -1,0 +1,204 @@
+export interface SLMAgent {
+  id: string;
+  cluster: string;
+  name: string;
+  keyword: string;
+  specialization: string;
+  brilliance: number;
+}
+
+function agent(id: string, cluster: string, name: string, keyword: string, specialization: string, brilliance = 0.95): SLMAgent {
+  return { id, cluster, name, keyword, specialization, brilliance };
+}
+
+export const SLM_AGENTS_LIST: SLMAgent[] = [
+  // Core Architecture
+  agent('A1', 'Core Architecture', 'Backend Architect', '/backend-architect', 'REST APIs, microservices, data models, system design, FastAPI, SQL', 0.98),
+  agent('A2', 'Core Architecture', 'Frontend Developer', '/frontend-developer', 'React, Vite, CSS, component architecture, UI state management', 0.95),
+  agent('A3', 'Core Architecture', 'Mobile Developer', '/mobile-developer', 'iOS, Android, React Native, cross-platform mobile architecture', 0.96),
+  agent('A4', 'Core Architecture', 'GraphQL Architect', '/graphql-architect', 'GraphQL schema design, resolvers, federation, subscriptions', 0.95),
+  agent('A5', 'Core Architecture', 'Architect Reviewer', '/architect-reviewer', 'Code quality review, design critique, architectural trade-offs, best practices', 0.99),
+
+  // Language Specialists
+  agent('L1', 'Language Specialists', 'Python Pro', '/python-pro', 'Python, FastAPI, Celery, asyncio, data processing, scripting', 0.99),
+  agent('L2', 'Language Specialists', 'JavaScript Pro', '/javascript-pro', 'Node.js, TypeScript, npm tooling, ESM, bundlers', 0.98),
+  agent('L3', 'Language Specialists', 'Golang Pro', '/golang-pro', 'Go services, CLI tools, concurrency patterns, gRPC', 0.97),
+  agent('L4', 'Language Specialists', 'Rust Pro', '/rust-pro', 'Rust systems programming, memory safety, performance-critical code, WebAssembly', 0.99),
+  agent('L5', 'Language Specialists', 'C Pro', '/c-pro', 'C low-level systems, embedded, OS interfaces, memory management', 0.98),
+  agent('L6', 'Language Specialists', 'C++ Pro', '/cpp-pro', 'C++ engine architecture, templates, RAII, performance optimization', 0.98),
+  agent('L7', 'Language Specialists', 'SQL Pro', '/sql-pro', 'SQL queries, schema design, indexing, query optimization, migrations', 0.99),
+
+  // Data & AI
+  agent('D1', 'Data & AI', 'AI Engineer', '/ai-engineer', 'LLMs, agentic systems, RAG pipelines, embeddings, vision models, Groq', 0.97),
+  agent('D2', 'Data & AI', 'ML Engineer', '/ml-engineer', 'Model training, evaluation, fine-tuning, PyTorch, HuggingFace', 0.98),
+  agent('D3', 'Data & AI', 'MLOps Engineer', '/mlops-engineer', 'ML pipelines, model serving, monitoring, experiment tracking', 0.97),
+  agent('D4', 'Data & AI', 'Data Engineer', '/data-engineer', 'ETL pipelines, data lakes, Spark, Airflow, dbt', 0.98),
+  agent('D5', 'Data & AI', 'Data Scientist', '/data-scientist', 'Statistical analysis, feature engineering, model selection, Pandas, sklearn', 0.97),
+
+  // Infrastructure & Cloud
+  agent('I1', 'Infra & Cloud', 'Cloud Architect', '/cloud-architect', 'AWS, GCP, Azure architecture, multi-cloud, cost optimization', 0.97),
+  agent('I2', 'Infra & Cloud', 'Terraform Specialist', '/terraform-specialist', 'Terraform, Pulumi, IaC patterns, cloud provisioning', 0.98),
+  agent('I3', 'Infra & Cloud', 'Network Engineer', '/network-engineer', 'Networking, DNS, VPN, load balancing, CDN, firewalls', 0.96),
+  agent('I4', 'Infra & Cloud', 'Deployment Engineer', '/deployment-engineer', 'CI/CD pipelines, Docker, Kubernetes, Helm, ngrok, release automation', 0.94),
+
+  // Operations
+  agent('O1', 'Operations', 'DevOps Troubleshooter', '/devops-troubleshooter', 'Infrastructure debugging, log analysis, incident diagnosis, monitoring', 0.97),
+  agent('O2', 'Operations', 'Incident Responder', '/incident-responder', 'Incident response playbooks, root cause analysis, postmortems', 0.99),
+  agent('O3', 'Operations', 'Database Admin', '/database-admin', 'Database schema, indexing strategy, replication, backups', 0.98),
+  agent('O4', 'Operations', 'Database Optimizer', '/database-optimizer', 'Query performance, execution plans, caching, connection pooling', 0.99),
+
+  // Quality & Security
+  agent('Q1', 'Quality & Security', 'Security Auditor', '/security-auditor', 'Vulnerability scanning, OWASP, threat modeling, penetration testing concepts', 1.00),
+  agent('Q2', 'Quality & Security', 'Security Hardening', '/security-hardening', 'Hardening implementation, secrets management, auth flows, encryption', 0.99),
+  agent('Q3', 'Quality & Security', 'Code Reviewer', '/code-reviewer', 'Code quality, patterns, readability, maintainability, SOLID principles', 0.98),
+  agent('Q4', 'Quality & Security', 'Debugger', '/debugger', 'Root cause analysis, stack traces, logging, Sentry, systematic debugging', 0.96),
+  agent('Q5', 'Quality & Security', 'Error Detective', '/error-detective', 'Error pattern analysis, edge cases, defensive programming', 0.97),
+  agent('Q6', 'Quality & Security', 'Performance Engineer', '/performance-engineer', 'Profiling, bottleneck identification, memory optimization, benchmarking', 0.98),
+  agent('Q7', 'Quality & Security', 'Test Automator', '/test-automator', 'Unit tests, integration tests, E2E testing, test coverage strategy', 0.98),
+
+  // Business Strategy
+  agent('B1', 'Business Strategy', 'Business Analyst', '/business-analyst', 'Requirements analysis, process mapping, stakeholder alignment, specs', 0.96),
+  agent('B2', 'Business Strategy', 'Quant Analyst', '/quant-analyst', 'Quantitative analysis, financial modeling, metrics, statistical reasoning', 0.98),
+  agent('B3', 'Business Strategy', 'Risk Manager', '/risk-manager', 'Risk assessment, mitigation strategies, compliance, contingency planning', 0.97),
+
+  // Growth & Sales
+  agent('G1', 'Growth & Sales', 'Content Marketer', '/content-marketer', 'Content strategy, SEO, copywriting, brand voice, content calendars', 0.95),
+  agent('G2', 'Growth & Sales', 'Sales Automator', '/sales-automator', 'Sales automation, CRM, outreach sequences, conversion optimization', 0.96),
+  agent('G3', 'Growth & Sales', 'Customer Support', '/customer-support', 'Support systems, help documentation, escalation flows, user empathy', 0.94),
+
+  // Utility
+  agent('U1', 'Utility', 'Context Manager', '/context-manager', 'State management, context preservation, session handling, memory systems', 0.99),
+  agent('U2', 'Utility', 'Prompt Engineer', '/prompt-engineer', 'Prompt optimization, chain-of-thought, few-shot examples, instruction tuning', 0.99),
+  agent('U3', 'Utility', 'Search Specialist', '/search-specialist', 'Research strategies, web search, information synthesis, fact verification', 0.98),
+  agent('U4', 'Utility', 'API Documenter', '/api-documenter', 'API docs, OpenAPI specs, README writing, code examples', 0.97),
+  agent('U5', 'Utility', 'DX Optimizer', '/dx-optimizer', 'Developer experience, tooling, onboarding, workflow automation', 0.96),
+  agent('U6', 'Utility', 'Legacy Modernizer', '/legacy-modernizer', 'Legacy system migration, refactoring strategies, incremental modernization', 0.98),
+
+  // Security Core
+  agent('SEC-Ω', 'Security Core', 'Sovereign Security Warden', '/security-core', 'Full-spectrum security: audit, hardening, compliance, threat intelligence, zero-trust', 1.00),
+
+  // Physics & Embodied Systems
+  agent('COS-01', 'Core Coordinator', 'Central Coordinator (Digital Brain)', '/central-coordinator', 'Multi-agent orchestration, task routing, system coordination, cognitive architecture', 0.99),
+  agent('COS-02', 'Embodied Intelligence', 'Embodied Robotics Agent', '/embodied-robotics', 'Physical AI, robotics simulation, sensor fusion, robot control systems', 0.98),
+  agent('COS-03', 'Physics Engine', 'Physics Simulation Agent', '/physics-sim', 'Physics simulation, PhysX, Isaac Sim, rigid body dynamics', 0.98),
+  agent('COS-04', 'Autonomous Systems', 'Autonomous Driving Agent', '/autonomous-driving', 'Autonomous driving, world models, sensor fusion, path planning', 0.97),
+  agent('COS-05', 'Human Modeling', 'Digital Human & Motion Agent', '/digital-human', 'Digital humans, motion capture, animation synthesis, avatar systems', 0.97),
+  agent('COS-06', 'Industrial Ops', 'Warehouse Operations Agent', '/warehouse-ops', 'Warehouse automation, robotics logistics, inventory systems', 0.96),
+  agent('COS-07', 'Spatial Intelligence', 'Spatial Reasoning Agent', '/spatial-reasoning', 'Spatial reasoning, 3D scene understanding, geometry, mapping', 0.98),
+
+  // Symbiosis Layer
+  agent('SYM-01', 'Symbiosis Layer', 'Perception & Spatial Node', '/extended-eyes', 'Visual parsing, image analysis, spatial perception, scene description', 0.98),
+  agent('SYM-02', 'Symbiosis Layer', 'Execution & Tooling Node', '/extended-hands', 'Tool execution, MCP integration, shell commands, automation actions', 0.99),
+
+  // Discovery & Strategy
+  agent('S1a', 'Discovery & Strategy', 'Vision Mapper', '/vision-mapper', 'Vision definition, goal mapping, strategic intent, roadmap framing', 0.95),
+  agent('S1b', 'Discovery & Strategy', 'Market Radar', '/market-radar', 'Market analysis, competitor research, trend identification', 0.95),
+  agent('S1c', 'Discovery & Strategy', 'Opportunity Analyst', '/opportunity-analyst', 'Opportunity sizing, feasibility analysis, gap identification', 0.95),
+  agent('S1d', 'Discovery & Strategy', 'Roadmap Curator', '/roadmap-curator', 'Product roadmap, prioritization, milestone planning, dependency mapping', 0.95),
+
+  // Design & Experience
+  agent('S2a', 'Design & Experience', 'UX Architect', '/ux-architect', 'User experience architecture, information architecture, user flows', 0.96),
+  agent('S2b', 'Design & Experience', 'Visual Systems', '/visual-systems', 'Design systems, visual language, component libraries, brand consistency', 0.95),
+  agent('S2c', 'Design & Experience', 'Interaction Designer', '/interaction-designer', 'Interaction patterns, micro-interactions, usability, prototyping', 0.95),
+  agent('S2d', 'Design & Experience', 'Accessibility Advocate', '/accessibility-advocate', 'WCAG compliance, a11y auditing, inclusive design, screen readers', 0.96),
+
+  // Architecture & Engineering
+  agent('S3a', 'Architecture & Engineering', 'Systems Architect', '/systems-architect', 'System design, distributed systems, scalability, resilience patterns', 0.97),
+  agent('S3b', 'Architecture & Engineering', 'API Designer', '/api-designer', 'API design, REST/GraphQL/gRPC, versioning, contract-first design', 0.96),
+  agent('S3c', 'Architecture & Engineering', 'Core Engineer', '/core-engineer', 'Core platform engineering, foundational libraries, shared infrastructure', 0.97),
+  agent('S3d', 'Architecture & Engineering', 'Integration Engineer', '/integration-engineer', 'System integration, webhooks, event buses, third-party APIs, connectors', 0.96),
+
+  // Data & Intelligence
+  agent('S4a', 'Data & Intelligence', 'Data Modeler', '/data-modeler', 'Data modeling, entity relationships, normalization, schema evolution', 0.97),
+  agent('S4b', 'Data & Intelligence', 'Analytics Engineer', '/analytics-engineer', 'Analytics pipelines, BI tooling, dbt models, data marts', 0.97),
+  agent('S4c', 'Data & Intelligence', 'ML Strategist', '/ml-strategist', 'ML project strategy, model selection, evaluation frameworks, ROI', 0.97),
+  agent('S4d', 'Data & Intelligence', 'Insights Synthesizer', '/insights-synthesizer', 'Synthesizing data insights, narrative generation, executive summaries', 0.96),
+
+  // Quality & Reliability
+  agent('S5a', 'Quality & Reliability', 'Test Architect', '/test-architect', 'Test strategy, test pyramid, coverage goals, testing frameworks', 0.97),
+  agent('S5b', 'Quality & Reliability', 'Reliability Engineer', '/reliability-engineer', 'SRE, SLOs/SLAs, error budgets, chaos engineering, runbooks', 0.97),
+  agent('S5c', 'Quality & Reliability', 'Performance Analyst', '/performance-analyst', 'Load testing, capacity planning, latency analysis, throughput optimization', 0.97),
+  agent('S5d', 'Quality & Reliability', 'Security Reviewer', '/security-reviewer', 'Security code review, dependency auditing, SAST/DAST, CVE triage', 0.97),
+
+  // Operations & Delivery
+  agent('S6a', 'Operations & Delivery', 'Release Manager', '/release-manager', 'Release planning, deployment gates, rollback strategies, changelogs', 0.97),
+  agent('S6b', 'Operations & Delivery', 'SRE Lead', '/sre-lead', 'SRE practices, on-call, alerting, dashboards, incident management', 0.97),
+  agent('S6c', 'Operations & Delivery', 'Incident Coordinator', '/incident-coordinator', 'Incident coordination, war rooms, stakeholder communication, timelines', 0.97),
+  agent('S6d', 'Operations & Delivery', 'Cost Optimizer', '/cost-optimizer', 'Cloud cost optimization, resource rightsizing, waste elimination', 0.97),
+
+  // Growth & Adoption
+  agent('S7a', 'Growth & Adoption', 'Acquisition Strategist', '/acquisition-strategist', 'User acquisition, growth funnels, channel strategy, conversion', 0.95),
+  agent('S7b', 'Growth & Adoption', 'Lifecycle Marketer', '/lifecycle-marketer', 'Email marketing, retention, user lifecycle, churn reduction', 0.95),
+  agent('S7c', 'Growth & Adoption', 'Sales Enablement', '/sales-enablement', 'Sales collateral, battlecards, demo scripts, objection handling', 0.95),
+  agent('S7d', 'Growth & Adoption', 'Customer Success', '/customer-success', 'Customer success playbooks, health scoring, expansion motions', 0.95),
+
+  // Governance & Stewardship
+  agent('S8a', 'Governance & Stewardship', 'Compliance Steward', '/compliance-steward', 'Regulatory compliance, GDPR, SOC2, audit trails, data governance', 0.97),
+  agent('S8b', 'Governance & Stewardship', 'Policy Engineer', '/policy-engineer', 'Policy as code, OPA, access control policies, governance automation', 0.97),
+  agent('S8c', 'Governance & Stewardship', 'Risk Assessor', '/risk-assessor', 'Risk scoring, threat assessment, business impact analysis', 0.97),
+  agent('S8d', 'Governance & Stewardship', 'Ethics Guardian', '/ethics-guardian', 'AI ethics, bias detection, responsible AI, fairness auditing', 0.97),
+
+  // Special / Infra Tools
+  agent('CW1', 'Infra & Cloud', 'CLI Architect', '/cweb', 'CLI tool design, shell scripting, automation, devtool UX', 0.95),
+  agent('OC1', 'Core Architecture', 'OpenClaw Operator', '/openclaw', 'OpenClaw integration, specialized tooling, operator patterns', 0.95),
+  agent('LM1', 'Data & AI', 'LM Studio Operator', '/lmstudio', 'Local LLM operation, LM Studio, model management, inference optimization', 0.92),
+];
+
+export const SLM_AGENTS: Record<string, SLMAgent> = Object.fromEntries(
+  SLM_AGENTS_LIST.map(a => [a.id, a]),
+);
+
+export function buildAgentSystemPrompt(agent: SLMAgent): string {
+  return `You are ${agent.name} (Node ${agent.id}), an expert specialist in the Sovereign Liquid Matrix (SLM-v3).
+
+Cluster: ${agent.cluster}
+Domain: ${agent.specialization}
+Brilliance: ${agent.brilliance}
+
+## ELITE QUALITY MANDATE — Non-Negotiable
+Your output will be cross-examined by specialist reviewers, a security validator, and a final synthesis agent before reaching the user. The assembled response goes directly to a senior engineer using it in production. There is no reviewer to catch what you miss — you are the expert.
+
+Standards enforced at every output, without exception:
+- Every code block must execute without modification. Mentally run it line by line before submitting. If an import might be missing, add it. If a variable might be undefined, handle it.
+- Every performance, compatibility, or behavior claim must be precise and defensible. Do not assert things you are not certain of.
+- If web research context is provided in the user prompt, you MUST use it. Do not rely on potentially stale training knowledge when authoritative current documentation is available.
+- If you cannot produce expert-tier output for a required section, state exactly what is needed and why rather than producing filler. A clear gap statement is better than a confident wrong answer.
+- Surface-level or partial responses will be flagged by reviewers and sent back for complete revision. Depth is required, not optional.
+
+## Operational Directives
+1. Stay strictly within your domain. Do not produce output outside your specialization.
+2. Deliver production-ready work — actual runnable code, real configurations, concrete decisions. Never pseudocode, never vague suggestions without a concrete implementation.
+3. If the user specifies a programming language or technology, use EXACTLY that. Do not substitute an alternative. A Python request gets Python. A Go request gets Go. No exceptions.
+4. Apply best practices without being prompted:
+   - Escape all user-controlled data inserted into HTML, SQL, or shell commands
+   - Handle all realistic failure modes (null/None, network timeouts, empty inputs, malformed data)
+   - Never hardcode credentials, tokens, or secrets — use environment variables or config injection
+   - Use idiomatic, production-grade patterns for the target language and framework
+5. Self-review before submitting: mentally execute your code, check imports exist, verify logic is sound, catch security holes, confirm all requested features are implemented.
+6. Be maximally concrete: name the specific library version, write the actual regex, show the exact config value. Vague guidance is worse than silence.
+7. ARCHITECTURE MANDATE — Never collapse structure for brevity. This is a hard rule:
+   - If the system has natural module boundaries (config, database, auth, services, API routes, models), deliver EACH as a separate, fully-written file with its correct path as a header comment.
+   - Example: a FastAPI project must have separate files for main.py, config.py, database.py, models.py, each service, each router — never merged into one file.
+   - Consolidating multiple modules into a single file to save space is automatic review failure. Reviewers are explicitly instructed to hard-fail architecture collapse.
+   - Every file must be complete and self-contained — no "...rest of file..." ellipsis, no truncation, no "add your logic here" stubs.
+
+## Response Format
+- Open with: [${agent.id} · ${agent.name}]
+- Deliver your complete, self-contained work
+- Close with: **Confidence:** [0.00–1.00] | **Coverage:** [what you fully addressed] | **Gaps:** [out-of-scope items or known limitations]`;
+}
+
+export function buildOrchestratorRoster(): string {
+  const clusters = new Map<string, SLMAgent[]>();
+  for (const agent of SLM_AGENTS_LIST) {
+    if (!clusters.has(agent.cluster)) clusters.set(agent.cluster, []);
+    clusters.get(agent.cluster)!.push(agent);
+  }
+  const lines: string[] = [];
+  for (const [cluster, agents] of clusters) {
+    lines.push(`**${cluster}**`);
+    for (const a of agents)
+      lines.push(`- ${a.id} · ${a.name} — ${a.specialization.split(',')[0].trim()} (⭐ ${a.brilliance})`);
+  }
+  return lines.join('\n');
+}

--- a/src/modules/slm/slm.pipeline.ts
+++ b/src/modules/slm/slm.pipeline.ts
@@ -215,9 +215,15 @@ async function executeAgents(
   onAgentComplete: (output: AgentOutput) => void,
   abortSignal: AbortSignal,
 ): Promise<AgentOutput[]> {
-  const agentPromises = plan.agents.map(async ({ id, task }): Promise<AgentOutput | null> => {
+  const outputs: AgentOutput[] = [];
+
+  // Sequential execution - local model servers (LM Studio, Ollama) only handle
+  // one concurrent request; parallel calls cause all but one to fail silently.
+  for (const { id, task } of plan.agents) {
+    if (abortSignal.aborted) break;
+
     const agentDef = SLM_AGENTS[id];
-    if (!agentDef) return null;
+    if (!agentDef) continue;
 
     const systemPrompt = buildAgentSystemPrompt(agentDef);
 
@@ -230,13 +236,11 @@ async function executeAgents(
       `## Delivery Standard\nProduce a complete, production-ready deliverable — working code, not sketches. If the task names a language or technology, use exactly that. Apply security best practices, robust error handling, and idiomatic patterns without being asked. If web research is provided above, you MUST use it to ensure your output reflects current, accurate documentation — do not rely on potentially outdated training knowledge when authoritative source material is available.\n\n**STRUCTURE MANDATE**: If this task involves a system with multiple logical components (config, database, auth, services, routes, models, etc.), you MUST deliver each as a separate, complete file. Show the file path as a comment at the top of each file. Do NOT consolidate modules into a single file for brevity — that is treated as an incomplete delivery and will be sent back for full revision. Every file must be written in its entirety with no truncation.`,
     );
 
-    const userPrompt = parts.join('\n\n');
-
     try {
       const result = await aixChatGenerateText_Simple(
         llmId,
         systemPrompt,
-        userPrompt,
+        parts.join('\n\n'),
         'chat-react-turn',
         `slm-agent-${id}`,
         { abortSignal },
@@ -246,19 +250,14 @@ async function executeAgents(
       const confidence = confidenceMatch ? parseFloat(confidenceMatch[1]) : agentDef.brilliance;
 
       const output: AgentOutput = { id, name: agentDef.name, task, result, confidence };
+      outputs.push(output);
       onAgentComplete(output);
-      return output;
     } catch {
-      return null;
+      // one agent failing should not stop the rest
     }
-  });
+  }
 
-  // allSettled: one agent failure never kills the rest
-  const results = await Promise.allSettled(agentPromises);
-  return results
-    .filter((r): r is PromiseFulfilledResult<AgentOutput | null> => r.status === 'fulfilled')
-    .map(r => r.value)
-    .filter((r): r is AgentOutput => r !== null);
+  return outputs;
 }
 
 
@@ -770,12 +769,40 @@ export async function runSLMPipeline(params: {
   }
   emit('✅ Enhancement complete\n');
 
+  // Phase 6b: Post-Enhancement Review
+  // Re-runs the reviewer panel on the enhanced outputs to catch anything the
+  // enhancer introduced before committing to final assembly.
+  emit('**Phase 6b — Post-Enhancement Review**');
+  emit(`_Re-auditing enhanced outputs before final assembly..._`);
+  const postEnhanceReviews = await reviewOutputs(enhancedOutputs, userMessage, llmId, plan.reviewers, abortSignal);
+  const postEnhanceFailed = postEnhanceReviews.filter(r => !r.passed);
+
+  if (postEnhanceReviews.length > 0) {
+    emit('');
+    for (const r of postEnhanceReviews) {
+      const icon = r.passed ? '✅' : '⚠️';
+      const scorePct = Math.round(r.score * 100);
+      const fb = r.feedback ? ` — _${preview(r.feedback, 160)}_` : '';
+      emit(`- ${icon} \`${r.agentId}\` · score **${scorePct}%**${fb}`);
+    }
+    emit('');
+  }
+
+  let assemblyInputs = enhancedOutputs;
+  if (postEnhanceFailed.length > 0) {
+    emit(`⚠️ ${postEnhanceFailed.length} issue(s) found after enhancement — applying targeted fixes\n`);
+    assemblyInputs = await fixFailedOutputs(postEnhanceReviews, enhancedOutputs, userMessage, llmId, abortSignal);
+    emit('✅ Post-enhancement fixes applied\n');
+  } else {
+    emit('✅ All outputs clear — proceeding to assembly\n');
+  }
+
   // Phase 7: Assemble
   emit('**Phase 7 — Final Assembly**');
-  emit(`_Synthesizing outputs from ${enhancedOutputs.length} agent contribution(s) into unified response..._`);
-  emit(`_Contributors: ${enhancedOutputs.map(o => `\`${o.id}\``).join(', ')}_\n`);
+  emit(`_Synthesizing outputs from ${assemblyInputs.length} agent contribution(s) into unified response..._`);
+  emit(`_Contributors: ${assemblyInputs.map(o => `\`${o.id}\``).join(', ')}_\n`);
 
-  const finalOutput = await assembleOutput(enhancedOutputs, userMessage, llmId, abortSignal);
+  const finalOutput = await assembleOutput(assemblyInputs, userMessage, llmId, abortSignal);
 
   emit('---\n');
   emit('## ✦ Final Output\n');

--- a/src/modules/slm/slm.pipeline.ts
+++ b/src/modules/slm/slm.pipeline.ts
@@ -1,0 +1,809 @@
+import { callBrowseFetchPageOrThrow } from '~/modules/browse/browse.client';
+import { useBrowseStore } from '~/modules/browse/store-module-browsing';
+import { aixChatGenerateText_Simple } from '~/modules/aix/client/aix.client';
+import type { DLLMId } from '~/common/stores/llms/llms.types';
+import { messageFragmentsReduceText } from '~/common/stores/chat/chat.message';
+import type { DMessage } from '~/common/stores/chat/chat.message';
+
+import { SLM_AGENTS, buildAgentSystemPrompt, buildOrchestratorRoster } from './slm.agents';
+
+
+// Outputs scoring below this after Phase 5 Validation trigger a second targeted fix pass.
+const VALIDATION_PASS_THRESHOLD = 0.80;
+
+
+// --- Types ---
+
+interface AgentTask {
+  id: string;
+  task: string;
+}
+
+interface OrchestratorPlan {
+  analysis: string;
+  agents: AgentTask[];
+  reviewers: string[];
+  enhancer: string;
+}
+
+interface AgentOutput {
+  id: string;
+  name: string;
+  task: string;
+  result: string;
+  confidence: number;
+}
+
+interface ReviewResult {
+  agentId: string;
+  passed: boolean;
+  feedback: string;
+  score: number;
+}
+
+type ProgressCallback = (text: string, done: boolean) => void;
+
+
+// --- Phase 1: Planning ---
+
+async function planAgents(
+  userMessage: string,
+  conversationContext: string,
+  llmId: DLLMId,
+  abortSignal: AbortSignal,
+): Promise<OrchestratorPlan> {
+  const roster = buildOrchestratorRoster();
+
+  const planningPrompt = `You are the SLM Orchestrator. Analyze this request and produce an optimal agent execution plan.
+
+## Available Agent Roster
+${roster}
+
+## User Request
+${userMessage}
+
+${conversationContext ? `## Conversation Context\n${conversationContext}` : ''}
+
+## Constraint Extraction (reason through this before selecting agents)
+Identify from the request:
+- Explicit programming language(s) (e.g., "Python", "TypeScript", "Go")
+- Frameworks or libraries named
+- Output type (script, API endpoint, UI component, config file, documentation, etc.)
+- Hard constraints ("must use X", "without Y", "only Z")
+- Architecture scope: Is this a multi-component system (API + DB + auth + services)? If yes, each agent task description MUST include the instruction: "Deliver as a complete multi-file project — separate file per module, each with its full path as a header comment. Do not consolidate into a single file."
+
+## Agent Selection Rules
+- Select 2–4 agents whose domains DIRECTLY cover distinct parts of the request. Overlap wastes cycles.
+- LANGUAGE ENFORCEMENT: If the user names a specific programming language, assign ONLY the matching language specialist. Python → L1. JavaScript/Node.js → L2. Go → L3. Rust → L4. SQL → L7. NEVER assign a language specialist to produce output in a different language than requested.
+- Each agent's task description MUST explicitly state the target language/technology so the agent cannot drift.
+- Only use agent IDs that appear in the roster above. Do not invent agent IDs.
+- Reviewers: always include Q3 for code tasks. Include Q1 for security-sensitive work. Include Q4 for debugging tasks.
+- Enhancer: choose the agent best positioned to elevate the final output quality (often Q3, Q6, or A5).
+
+Return ONLY valid JSON (no markdown, no explanation):
+{
+  "analysis": "one-sentence summary of what this request needs",
+  "agents": [
+    {"id": "AGENT_ID", "task": "specific task with explicit language/tech constraint"}
+  ],
+  "reviewers": ["Q3"],
+  "enhancer": "AGENT_ID"
+}`;
+
+  const raw = await aixChatGenerateText_Simple(
+    llmId,
+    'You are the SLM Orchestrator. Output only valid JSON.',
+    planningPrompt,
+    'chat-react-turn',
+    'slm-plan',
+    { abortSignal },
+  );
+
+  try {
+    const jsonMatch = raw.match(/\{[\s\S]*\}/);
+    if (jsonMatch) return JSON.parse(jsonMatch[0]) as OrchestratorPlan;
+  } catch {
+    // fallback below
+  }
+
+  return {
+    analysis: 'General request — routing to core agents',
+    agents: [
+      { id: 'A1', task: userMessage },
+      { id: 'Q3', task: `Review the response for quality and correctness: ${userMessage}` },
+    ],
+    reviewers: ['Q3'],
+    enhancer: 'A1',
+  };
+}
+
+
+// --- Phase 1.5: Web Research ---
+// Fetches live documentation, API references, or authoritative sources when they would
+// materially improve agent output accuracy. Silently skips if browse is not configured
+// or if the task does not require external grounding.
+
+async function gatherWebResearch(
+  userMessage: string,
+  plan: OrchestratorPlan,
+  llmId: DLLMId,
+  abortSignal: AbortSignal,
+): Promise<string> {
+  const { wssEndpoint } = useBrowseStore.getState();
+  const browseEnabled = typeof wssEndpoint === 'string' && wssEndpoint.length > 8;
+  if (!browseEnabled) return '';
+
+  const researchPlanPrompt = `You are the SLM Research Director. Decide if the following task requires live web research to ensure accuracy.
+
+## User Request
+${userMessage}
+
+## Planned Agents
+${plan.agents.map(a => `${a.id}: ${a.task}`).join('\n')}
+
+Research is warranted when the task involves:
+- A specific library, framework, or API where version-specific documentation matters
+- A tool or technology where best practices have evolved recently
+- A topic where citing authoritative sources would substantially improve answer quality
+
+Research is NOT warranted for:
+- General programming patterns or algorithms
+- Simple explanations or creative tasks
+- Anything fully covered by common knowledge in the model's training
+
+If research is warranted, provide up to 3 highly specific, directly relevant URLs (official docs, spec pages, authoritative references — not blog posts or forums).
+
+Return ONLY valid JSON:
+{
+  "needsResearch": true,
+  "reason": "one sentence explaining why",
+  "urls": ["https://..."]
+}`;
+
+  try {
+    const raw = await aixChatGenerateText_Simple(
+      llmId,
+      'You are the SLM Research Director. Output only valid JSON. No markdown wrapper.',
+      researchPlanPrompt,
+      'chat-react-turn',
+      'slm-research-plan',
+      { abortSignal },
+    );
+
+    const jsonMatch = raw.match(/\{[\s\S]*?\}/);
+    if (!jsonMatch) return '';
+
+    const researchPlan = JSON.parse(jsonMatch[0]) as { needsResearch: boolean; reason: string; urls?: string[] };
+    if (!researchPlan.needsResearch || !researchPlan.urls?.length) return '';
+
+    const fetchResults = await Promise.allSettled(
+      researchPlan.urls.slice(0, 3).map(async (url): Promise<string> => {
+        const page = await callBrowseFetchPageOrThrow(url);
+        let content = '';
+        if (typeof page.content === 'string') {
+          content = page.content;
+        } else if (page.content && typeof page.content === 'object') {
+          content = Object.values(page.content as Record<string, string>)[0] ?? '';
+        }
+        const trimmed = content.trim().slice(0, 4000);
+        if (!trimmed) return '';
+        return `### Source: ${url}\n${trimmed}`;
+      })
+    );
+
+    const gathered = fetchResults
+      .filter((r): r is PromiseFulfilledResult<string> => r.status === 'fulfilled' && r.value.length > 60)
+      .map(r => r.value)
+      .join('\n\n---\n\n');
+
+    return gathered
+      ? `## Live Web Research\n_Fetched for this task — agents must use this to ensure accuracy and currency._\n\n${gathered}`
+      : '';
+  } catch {
+    return '';
+  }
+}
+
+
+// --- Phase 2: Parallel Agent Execution ---
+
+async function executeAgents(
+  plan: OrchestratorPlan,
+  userMessage: string,
+  llmId: DLLMId,
+  researchContext: string,
+  onAgentComplete: (output: AgentOutput) => void,
+  abortSignal: AbortSignal,
+): Promise<AgentOutput[]> {
+  const agentPromises = plan.agents.map(async ({ id, task }): Promise<AgentOutput | null> => {
+    const agentDef = SLM_AGENTS[id];
+    if (!agentDef) return null;
+
+    const systemPrompt = buildAgentSystemPrompt(agentDef);
+
+    const parts = [
+      `## Your Task\n${task}`,
+      `## Full User Request\n${userMessage}`,
+    ];
+    if (researchContext) parts.push(researchContext);
+    parts.push(
+      `## Delivery Standard\nProduce a complete, production-ready deliverable — working code, not sketches. If the task names a language or technology, use exactly that. Apply security best practices, robust error handling, and idiomatic patterns without being asked. If web research is provided above, you MUST use it to ensure your output reflects current, accurate documentation — do not rely on potentially outdated training knowledge when authoritative source material is available.\n\n**STRUCTURE MANDATE**: If this task involves a system with multiple logical components (config, database, auth, services, routes, models, etc.), you MUST deliver each as a separate, complete file. Show the file path as a comment at the top of each file. Do NOT consolidate modules into a single file for brevity — that is treated as an incomplete delivery and will be sent back for full revision. Every file must be written in its entirety with no truncation.`,
+    );
+
+    const userPrompt = parts.join('\n\n');
+
+    try {
+      const result = await aixChatGenerateText_Simple(
+        llmId,
+        systemPrompt,
+        userPrompt,
+        'chat-react-turn',
+        `slm-agent-${id}`,
+        { abortSignal },
+      );
+
+      const confidenceMatch = result.match(/Confidence:\s*([\d.]+)/i);
+      const confidence = confidenceMatch ? parseFloat(confidenceMatch[1]) : agentDef.brilliance;
+
+      const output: AgentOutput = { id, name: agentDef.name, task, result, confidence };
+      onAgentComplete(output);
+      return output;
+    } catch {
+      return null;
+    }
+  });
+
+  // allSettled: one agent failure never kills the rest
+  const results = await Promise.allSettled(agentPromises);
+  return results
+    .filter((r): r is PromiseFulfilledResult<AgentOutput | null> => r.status === 'fulfilled')
+    .map(r => r.value)
+    .filter((r): r is AgentOutput => r !== null);
+}
+
+
+// --- Phase 3: Review ---
+
+async function reviewOutputs(
+  agentOutputs: AgentOutput[],
+  userMessage: string,
+  llmId: DLLMId,
+  reviewerIds: string[],
+  abortSignal: AbortSignal,
+): Promise<ReviewResult[]> {
+  const outputSummary = agentOutputs
+    .map(o => `### ${o.id} · ${o.name}\n${o.result}`)
+    .join('\n\n---\n\n');
+
+  const reviewResults: ReviewResult[] = [];
+
+  for (const reviewerId of reviewerIds) {
+    const reviewer = SLM_AGENTS[reviewerId];
+    if (!reviewer) continue;
+
+    const reviewPrompt = `## Original Request
+${userMessage}
+
+## Scoring Rubric (apply strictly — do not be generous)
+- 90–100%: Production-ready, expert-level. Complete, correct, secure, idiomatic. Handles realistic edge cases.
+- 70–89%: Good quality with minor gaps (one missing error case, a style issue). Fully addresses the request.
+- 40–69%: Partially addresses the request, or has meaningful correctness/completeness gaps.
+- 10–39%: Superficially related but fails the core requirement (wrong language, outline instead of implementation, broken logic).
+- 0–9%: Off-topic, dangerous, or completely wrong.
+
+## Hard Fail Criteria (passed: false, score ≤ 0.30 — enforce without exception)
+An output FAILS automatically if:
+- It uses a different programming language than explicitly requested
+- It is an outline, concept, or architectural plan when runnable code was requested
+- It introduces security vulnerabilities: XSS (user data inserted into HTML without escaping), SQL injection, hardcoded credentials, unvalidated shell inputs
+- It ignores the primary requirement of the task
+- ARCHITECTURE COLLAPSE: A multi-component system (API, backend service, framework app) is delivered as a single monolithic file when it should be a proper multi-file project structure. Example: a FastAPI application with auth, database, services, and routes must NOT be crammed into one main.py — it must be delivered as separate files (config.py, database.py, models.py, services/, routers/, etc.). A single-file delivery of a multi-module system is an automatic hard fail regardless of whether the code runs.
+- ANY file is truncated, uses ellipsis ("..."), or contains stub placeholders ("# add your logic here", "pass", "TODO") where real implementation is required
+
+## Agent Outputs to Review
+${outputSummary}
+
+Evaluate each output against the rubric and hard-fail criteria. Feedback must be specific and actionable — cite the exact issue and what the fix should be.
+Return JSON:
+{
+  "reviews": [
+    {"agentId": "ID", "passed": true/false, "feedback": "specific actionable feedback with exact issues cited", "score": 0.00}
+  ]
+}`;
+
+    try {
+      const raw = await aixChatGenerateText_Simple(
+        llmId,
+        buildAgentSystemPrompt(reviewer),
+        reviewPrompt,
+        'chat-react-turn',
+        `slm-review-${reviewerId}`,
+        { abortSignal },
+      );
+
+      const jsonMatch = raw.match(/\{[\s\S]*\}/);
+      if (jsonMatch) {
+        const parsed = JSON.parse(jsonMatch[0]);
+        if (parsed.reviews) reviewResults.push(...parsed.reviews);
+      }
+    } catch {
+      for (const o of agentOutputs)
+        reviewResults.push({ agentId: o.id, passed: true, feedback: '', score: o.confidence });
+    }
+  }
+
+  return reviewResults;
+}
+
+
+// --- Phase 4: Fix & Revision ---
+
+async function fixFailedOutputs(
+  reviewResults: ReviewResult[],
+  originalOutputs: AgentOutput[],
+  userMessage: string,
+  llmId: DLLMId,
+  abortSignal: AbortSignal,
+): Promise<AgentOutput[]> {
+  const failed = reviewResults.filter(r => !r.passed);
+  if (failed.length === 0) return originalOutputs;
+
+  const fixPromises = failed.map(async (review): Promise<AgentOutput | null> => {
+    const original = originalOutputs.find(o => o.id === review.agentId);
+    if (!original) return null;
+
+    const agentDef = SLM_AGENTS[original.id];
+    if (!agentDef) return null;
+
+    const fixPrompt = `## Review Feedback — Address EVERY point listed below
+${review.feedback}
+
+## Your Previous Output (to revise)
+${original.result}
+
+## Original Task
+${original.task}
+
+## User Request
+${userMessage}
+
+Produce a complete replacement that fully resolves every issue in the review feedback. If the previous output was in the wrong language, rewrite it entirely in the correct language. If there were security issues, apply the correct fix — not a comment about it. Do not patch around issues — fix them at the root. The output must pass: correct language, working code, no security vulnerabilities, complete implementation.`;
+
+    try {
+      const result = await aixChatGenerateText_Simple(
+        llmId,
+        buildAgentSystemPrompt(agentDef),
+        fixPrompt,
+        'chat-react-turn',
+        `slm-fix-${original.id}`,
+        { abortSignal },
+      );
+
+      return { ...original, result, confidence: Math.min(original.confidence + 0.02, 1.0) };
+    } catch {
+      return original;
+    }
+  });
+
+  const fixes = await Promise.allSettled(fixPromises);
+  const fixMap = new Map(
+    fixes
+      .filter((f): f is PromiseFulfilledResult<AgentOutput | null> => f.status === 'fulfilled')
+      .map(f => f.value)
+      .filter((f): f is AgentOutput => f !== null)
+      .map(f => [f.id, f]),
+  );
+
+  return originalOutputs.map(o => fixMap.get(o.id) ?? o);
+}
+
+
+// --- Phase 5: Validation ---
+
+async function validateOutputs(
+  agentOutputs: AgentOutput[],
+  userMessage: string,
+  llmId: DLLMId,
+  abortSignal: AbortSignal,
+): Promise<{ outputs: AgentOutput[]; validationScore: number; criticalIssues: string[] }> {
+  const validator = SLM_AGENTS['Q1'];
+  if (!validator) return { outputs: agentOutputs, validationScore: 0.95, criticalIssues: [] };
+
+  const outputSummary = agentOutputs.map(o => `### ${o.id} · ${o.name}\n${o.result}`).join('\n\n---\n\n');
+
+  const validatePrompt = `## User Request
+${userMessage}
+
+## All Agent Outputs
+${outputSummary}
+
+Run a thorough validation pass. Check each of the following explicitly:
+1. LANGUAGE COMPLIANCE: Is the output in the exact language/technology the user requested?
+2. SECURITY: Any XSS (user data in HTML without escaping)? SQL injection? Hardcoded credentials? Unvalidated inputs passed to shell/SQL?
+3. CORRECTNESS: Does every code block actually run? Are all imports present? Any logic bugs or off-by-one errors?
+4. COMPLETENESS: Does the response fully address the user's request? Any required components missing or stubbed out?
+5. EDGE CASES: Are obvious failure modes handled — null/None values, network errors, empty inputs, type mismatches?
+
+Score based on how many of the above pass cleanly. Cite every specific issue found. Classify issues: regular issues reduce score; critical issues (security bugs, wrong language, broken code that won't run) must be listed separately and will trigger a mandatory fix pass.
+
+Return JSON:
+{
+  "validationScore": 0.00,
+  "issues": ["specific issue description"],
+  "criticalIssues": ["issues requiring mandatory remediation — security bugs, wrong language, unrunnable code"],
+  "approved": true
+}`;
+
+  try {
+    const raw = await aixChatGenerateText_Simple(
+      llmId,
+      buildAgentSystemPrompt(validator),
+      validatePrompt,
+      'chat-react-turn',
+      'slm-validate',
+      { abortSignal },
+    );
+
+    const jsonMatch = raw.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      const parsed = JSON.parse(jsonMatch[0]);
+      return {
+        outputs: agentOutputs,
+        validationScore: parsed.validationScore ?? 0.95,
+        criticalIssues: Array.isArray(parsed.criticalIssues) ? parsed.criticalIssues : [],
+      };
+    }
+  } catch {
+    // fallthrough
+  }
+
+  return { outputs: agentOutputs, validationScore: 0.95, criticalIssues: [] };
+}
+
+
+// --- Phase 5b: Validation-Triggered Critical Fix ---
+// Only runs when validationScore < VALIDATION_PASS_THRESHOLD.
+// The Sovereign Security Warden (SEC-Ω) or Q1 applies surgical corrections
+// to every critical issue identified by the validator, then adds the fixed
+// content as a highest-authority contribution that the assembler must honor.
+
+async function resolveValidationFailures(
+  outputs: AgentOutput[],
+  criticalIssues: string[],
+  userMessage: string,
+  llmId: DLLMId,
+  abortSignal: AbortSignal,
+): Promise<AgentOutput[]> {
+  if (criticalIssues.length === 0) return outputs;
+
+  const corrector = SLM_AGENTS['SEC-Ω'] ?? SLM_AGENTS['Q1'];
+  if (!corrector) return outputs;
+
+  const outputSummary = outputs.map(o => `### ${o.id} · ${o.name}\n${o.result}`).join('\n\n---\n\n');
+
+  const fixPrompt = `## Critical Issues Identified by Validation
+${criticalIssues.map((issue, i) => `${i + 1}. ${issue}`).join('\n')}
+
+## All Agent Outputs
+${outputSummary}
+
+## User Request
+${userMessage}
+
+For EACH critical issue listed: identify which output is affected, then produce a corrected replacement for that section. Label corrections by agent ID. Be surgical and complete — rewrite the affected section with the exact fix applied. Do not summarize or give advice; produce the fixed code/content directly.
+
+These corrections carry the highest authority in the pipeline and will override original agent outputs in the final assembly.`;
+
+  try {
+    const correction = await aixChatGenerateText_Simple(
+      llmId,
+      buildAgentSystemPrompt(corrector),
+      fixPrompt,
+      'chat-react-turn',
+      'slm-validation-fix',
+      { abortSignal },
+    );
+
+    return [
+      ...outputs,
+      {
+        id: corrector.id,
+        name: `${corrector.name} (Validation Fix — Highest Authority)`,
+        task: 'Critical issue resolution',
+        result: correction,
+        confidence: 1.0,
+      },
+    ];
+  } catch {
+    return outputs;
+  }
+}
+
+
+// --- Phase 6: Enhancement ---
+
+async function enhanceOutputs(
+  agentOutputs: AgentOutput[],
+  userMessage: string,
+  enhancerId: string,
+  llmId: DLLMId,
+  abortSignal: AbortSignal,
+): Promise<AgentOutput[]> {
+  const enhancer = SLM_AGENTS[enhancerId] ?? SLM_AGENTS['U2'];
+  if (!enhancer) return agentOutputs;
+
+  const outputSummary = agentOutputs.map(o => `### ${o.id} · ${o.name}\n${o.result}`).join('\n\n---\n\n');
+
+  const enhancePrompt = `## Original Request
+${userMessage}
+
+## All Agent Outputs
+${outputSummary}
+
+You are performing the final quality-elevation pass. Identify the top 1–2 highest-impact improvements not yet addressed. Prioritize in this order:
+1. Security gaps — unescaped output, missing input validation, exposed credentials, unsafe HTML construction
+2. Correctness gaps — bugs, wrong API usage, missing imports, logic errors
+3. Completeness gaps — missing error handling, absent deployment guidance, uncovered edge cases
+4. Quality gaps — better idiomatic patterns, cleaner structure, improved readability
+
+For each improvement: deliver it as concrete, ready-to-use code or configuration — not advice. If a security fix requires rewriting a section, rewrite it.
+Return the enhanced content labeled: [ENHANCEMENT · ${enhancer.id}]`;
+
+  try {
+    const enhancement = await aixChatGenerateText_Simple(
+      llmId,
+      buildAgentSystemPrompt(enhancer),
+      enhancePrompt,
+      'chat-react-turn',
+      'slm-enhance',
+      { abortSignal },
+    );
+
+    return [
+      ...agentOutputs,
+      { id: enhancer.id, name: `${enhancer.name} (Enhancement)`, task: 'Enhancement pass', result: enhancement, confidence: enhancer.brilliance },
+    ];
+  } catch {
+    return agentOutputs;
+  }
+}
+
+
+// --- Phase 7: Final Assembly ---
+
+async function assembleOutput(
+  agentOutputs: AgentOutput[],
+  userMessage: string,
+  llmId: DLLMId,
+  abortSignal: AbortSignal,
+): Promise<string> {
+  const outputSummary = agentOutputs.map(o => `### ${o.id} · ${o.name}\n${o.result}`).join('\n\n---\n\n');
+
+  const assemblePrompt = `You are the SLM Orchestrator performing final synthesis. This response goes directly to a senior engineer who will use it in production. There is no room for gaps, stubs, or mediocrity.
+
+## User's Original Request
+${userMessage}
+
+## All Agent Contributions
+_Listed in order of authority. Entries marked "Highest Authority" or "Validation Fix" override earlier outputs on conflicting points._
+
+${outputSummary}
+
+## Expert Assembly Protocol — every point is mandatory
+1. COMPLETENESS: Fully solve what was asked. No TODOs, no "left as an exercise", no unimplemented stubs. Placeholder values (credentials, domain names) should be clearly labeled YOUR_VALUE_HERE only when they are inherently user-specific.
+2. CORRECTNESS: Cross-check all code logic, imports, and API calls. Fix every bug you identify — do not propagate agent errors. Where outputs conflict, use the higher-authority version.
+3. SECURITY: Apply all applicable security practices: escape user-controlled data before inserting into HTML/SQL/shell, use environment variables for credentials, validate at all system boundaries, never expose internal errors to users.
+4. COHERENCE: Strip all agent headers, phase labels, and internal meta-commentary. One voice, no contradictions, no duplicate content.
+5. USABILITY: Structure for immediate use by a developer reading top-to-bottom. Every code block must run as-is. Shell commands must be accurate. Install instructions must match the actual packages used.
+6. AUTHORITY HIERARCHY: Any contribution labeled "Validation Fix — Highest Authority" or "Enhancement" contains final corrections. These MUST be fully incorporated — they represent post-review corrections and override original agent outputs on any point they address.
+7. STRUCTURE PRESERVATION — CRITICAL: If any agent delivered a proper multi-file project structure, you MUST reproduce that full structure in the final output. Never flatten or collapse it. If agent A1 delivered separate files (main.py, config.py, database.py, models.py, etc.) and agent L1 delivered a single file, the multi-file version wins — always adopt the most architecturally complete version. Every file that appeared in any agent's output must appear in the final output, complete and untruncated. Present files in logical dependency order with their full path as a heading.
+
+Produce the response as if a single senior engineer with 30 years of deep cross-domain expertise wrote it from scratch after reviewing all agent contributions — complete, production-ready, immediately usable.`;
+
+  return await aixChatGenerateText_Simple(
+    llmId,
+    'You are the SLM Orchestrator. Synthesize agent outputs into a single perfect response.',
+    assemblePrompt,
+    'chat-react-turn',
+    'slm-assemble',
+    { abortSignal },
+  );
+}
+
+
+// --- Main Pipeline Entry Point ---
+
+export async function runSLMPipeline(params: {
+  userMessage: string;
+  conversationContext: string;
+  llmId: DLLMId;
+  abortSignal: AbortSignal;
+  onProgress: ProgressCallback;
+}): Promise<string> {
+  const { userMessage, conversationContext, llmId, abortSignal, onProgress } = params;
+
+  let log = '🛰️ **SLM Matrix Active**\n\n';
+  const emit = (line: string, done = false) => {
+    log += line + '\n';
+    onProgress(log, done);
+  };
+  const preview = (text: string, max = 280) => {
+    const trimmed = text.trim().replace(/\n+/g, ' ');
+    return trimmed.length > max ? trimmed.slice(0, max) + '…' : trimmed;
+  };
+
+  // Phase 1: Plan
+  emit('**Phase 1 — Analysis & Planning**');
+  emit('_Orchestrator decomposing request and selecting agents..._');
+
+  let plan: OrchestratorPlan;
+  try {
+    plan = await planAgents(userMessage, conversationContext, llmId, abortSignal);
+  } catch {
+    emit('⚠️ Planning failed — using fallback routing');
+    plan = {
+      analysis: 'Fallback routing',
+      agents: [{ id: 'A1', task: userMessage }],
+      reviewers: ['Q3'],
+      enhancer: 'U2',
+    };
+  }
+
+  emit(`📋 **${plan.analysis}**`);
+  emit('');
+  emit('**Agent Roster for this task:**');
+  for (const { id, task } of plan.agents) {
+    const def = SLM_AGENTS[id];
+    emit(`- \`${id}\` **${def?.name ?? id}** — _${preview(task, 120)}_`);
+  }
+  emit(`\nReviewers: ${plan.reviewers.map(r => `\`${r}\` ${SLM_AGENTS[r]?.name ?? r}`).join(', ')} · Enhancer: \`${plan.enhancer}\` ${SLM_AGENTS[plan.enhancer]?.name ?? plan.enhancer}\n`);
+
+  // Phase 1.5: Web Research
+  emit('**Phase 1.5 — Web Research**');
+  emit('_Checking whether live documentation or authoritative sources are needed..._');
+
+  let researchContext = '';
+  try {
+    researchContext = await gatherWebResearch(userMessage, plan, llmId, abortSignal);
+  } catch {
+    // non-fatal
+  }
+
+  if (researchContext) {
+    emit(`🌐 Research gathered — agents will use live source material\n`);
+  } else {
+    emit(`_No external research required for this task_\n`);
+  }
+
+  // Phase 2: Execute
+  emit('**Phase 2 — Parallel Agent Execution**');
+
+  const agentStatusMap = new Map<string, string>();
+  const agentOutputSnippetMap = new Map<string, string>();
+  for (const { id } of plan.agents) agentStatusMap.set(id, '⏳ queued');
+
+  const renderPhase2 = () =>
+    plan.agents.map(({ id }) => {
+      const def = SLM_AGENTS[id];
+      const status = agentStatusMap.get(id) ?? '⏳ queued';
+      const snippet = agentOutputSnippetMap.get(id);
+      const header = `- ${status} \`${id}\` · **${def?.name ?? id}**`;
+      return snippet ? `${header}\n  > ${snippet}` : header;
+    }).join('\n');
+
+  emit(renderPhase2() + '\n');
+
+  const agentOutputs = await executeAgents(
+    plan,
+    userMessage,
+    llmId,
+    researchContext,
+    (output) => {
+      agentStatusMap.set(output.id, `✅ done (${output.confidence.toFixed(2)})`);
+      agentOutputSnippetMap.set(output.id, preview(output.result, 240));
+      const idx = log.lastIndexOf('**Phase 2');
+      log = log.slice(0, idx) + '**Phase 2 — Parallel Agent Execution**\n' + renderPhase2() + '\n\n';
+      onProgress(log, false);
+    },
+    abortSignal,
+  );
+
+  // Phase 3: Review
+  emit('**Phase 3 — Review**');
+  emit(`_Reviewers: ${plan.reviewers.map(r => `\`${r}\` ${SLM_AGENTS[r]?.name ?? r}`).join(', ')} — auditing all agent outputs..._`);
+
+  const reviewResults = await reviewOutputs(agentOutputs, userMessage, llmId, plan.reviewers, abortSignal);
+  const failed = reviewResults.filter(r => !r.passed);
+
+  if (reviewResults.length > 0) {
+    emit('');
+    emit('**Review Scores:**');
+    for (const r of reviewResults) {
+      const icon = r.passed ? '✅' : '⚠️';
+      const scorePct = Math.round(r.score * 100);
+      const fb = r.feedback ? ` — _${preview(r.feedback, 160)}_` : '';
+      emit(`- ${icon} \`${r.agentId}\` · score **${scorePct}%**${fb}`);
+    }
+    emit('');
+  }
+
+  emit(failed.length === 0 ? '✅ All outputs passed review\n' : `⚠️ ${failed.length} output(s) flagged for revision\n`);
+
+  // Phase 4: Fix
+  let currentOutputs = agentOutputs;
+  if (failed.length > 0) {
+    emit('**Phase 4 — Fix & Revision**');
+    emit(`_Revising ${failed.length} agent output(s) based on reviewer feedback..._`);
+    for (const r of failed) {
+      const def = SLM_AGENTS[r.agentId];
+      emit(`  · Revising \`${r.agentId}\` ${def?.name ?? r.agentId}: _${preview(r.feedback, 180)}_`);
+    }
+    currentOutputs = await fixFailedOutputs(reviewResults, agentOutputs, userMessage, llmId, abortSignal);
+    emit('✅ Revisions complete\n');
+  }
+
+  // Phase 5: Validation
+  emit('**Phase 5 — Validation**');
+  emit('_Security Auditor running quality, safety & completeness checks..._');
+  const { outputs: validatedOutputs, validationScore, criticalIssues } = await validateOutputs(currentOutputs, userMessage, llmId, abortSignal);
+  const scoreBar = '█'.repeat(Math.round(validationScore * 10)) + '░'.repeat(10 - Math.round(validationScore * 10));
+  emit(`${validationScore >= VALIDATION_PASS_THRESHOLD ? '✅' : '⚠️'} Validation score: **${validationScore.toFixed(2)}/1.00** \`${scoreBar}\`\n`);
+
+  // Phase 5b: Validation-triggered critical fix
+  let postValidationOutputs = validatedOutputs;
+  if (validationScore < VALIDATION_PASS_THRESHOLD && criticalIssues.length > 0) {
+    emit('**Phase 5b — Critical Issue Resolution**');
+    emit(`_Score ${validationScore.toFixed(2)} below threshold (${VALIDATION_PASS_THRESHOLD}). Sovereign Security Warden resolving ${criticalIssues.length} critical issue(s)..._`);
+    for (const issue of criticalIssues) emit(`  · ${issue}`);
+    postValidationOutputs = await resolveValidationFailures(validatedOutputs, criticalIssues, userMessage, llmId, abortSignal);
+    emit('✅ Critical issues resolved\n');
+  }
+
+  // Phase 6: Enhancement
+  const enhancerDef = SLM_AGENTS[plan.enhancer];
+  emit('**Phase 6 — Enhancement**');
+  emit(`_${enhancerDef?.name ?? plan.enhancer} (\`${plan.enhancer}\`) performing cross-cutting quality elevation..._`);
+  const enhancedOutputs = await enhanceOutputs(postValidationOutputs, userMessage, plan.enhancer, llmId, abortSignal);
+  const enhancement = enhancedOutputs.find(o => o.id === (enhancerDef?.id ?? plan.enhancer) && o.name.includes('Enhancement'));
+  if (enhancement) {
+    emit(`\n**Enhancement added by \`${plan.enhancer}\`:**\n> ${preview(enhancement.result, 320)}\n`);
+  }
+  emit('✅ Enhancement complete\n');
+
+  // Phase 7: Assemble
+  emit('**Phase 7 — Final Assembly**');
+  emit(`_Synthesizing outputs from ${enhancedOutputs.length} agent contribution(s) into unified response..._`);
+  emit(`_Contributors: ${enhancedOutputs.map(o => `\`${o.id}\``).join(', ')}_\n`);
+
+  const finalOutput = await assembleOutput(enhancedOutputs, userMessage, llmId, abortSignal);
+
+  emit('---\n');
+  emit('## ✦ Final Output\n');
+  emit(finalOutput, true);
+
+  return log;
+}
+
+
+// --- Extract user message text from DMessage history ---
+
+export function extractLastUserMessageText(chatHistory: Readonly<DMessage[]>): string {
+  for (let i = chatHistory.length - 1; i >= 0; i--) {
+    const msg = chatHistory[i];
+    if (msg.role !== 'user') continue;
+    const text = messageFragmentsReduceText(msg.fragments);
+    if (text.trim()) return text;
+  }
+  return '';
+}
+
+export function buildConversationContext(chatHistory: Readonly<DMessage[]>, maxMessages = 6): string {
+  const recent = chatHistory.slice(-maxMessages);
+  return recent
+    .map(msg => {
+      const text = messageFragmentsReduceText(msg.fragments).trim().slice(0, 300);
+      return text ? `${msg.role}: ${text}` : null;
+    })
+    .filter(Boolean)
+    .join('\n');
+}

--- a/src/modules/slm/slm.pipeline.ts
+++ b/src/modules/slm/slm.pipeline.ts
@@ -54,7 +54,7 @@ async function planAgents(
 ): Promise<OrchestratorPlan> {
   const roster = buildOrchestratorRoster();
 
-  const planningPrompt = `You are the SLM Orchestrator. Analyze this request and produce an optimal agent execution plan.
+  const planningPrompt = `You are the SLM Orchestrator. Decompose this request into a precise execution plan.
 
 ## Available Agent Roster
 ${roster}
@@ -64,27 +64,33 @@ ${userMessage}
 
 ${conversationContext ? `## Conversation Context\n${conversationContext}` : ''}
 
-## Constraint Extraction (reason through this before selecting agents)
-Identify from the request:
-- Explicit programming language(s) (e.g., "Python", "TypeScript", "Go")
-- Frameworks or libraries named
-- Output type (script, API endpoint, UI component, config file, documentation, etc.)
-- Hard constraints ("must use X", "without Y", "only Z")
-- Architecture scope: Is this a multi-component system (API + DB + auth + services)? If yes, each agent task description MUST include the instruction: "Deliver as a complete multi-file project — separate file per module, each with its full path as a header comment. Do not consolidate into a single file."
+## Step 1 — Analyze the request
+Before writing the plan, identify:
+- What is the core deliverable? (code, docs, design, analysis, strategy?)
+- What technologies/languages are named or implied?
+- Is this a multi-component system? If yes, flag it.
+- What would a fully complete, high-quality response look like? List every part.
 
-## Agent Selection Rules
-- Select 2–4 agents whose domains DIRECTLY cover distinct parts of the request. Overlap wastes cycles.
-- LANGUAGE ENFORCEMENT: If the user names a specific programming language, assign ONLY the matching language specialist. Python → L1. JavaScript/Node.js → L2. Go → L3. Rust → L4. SQL → L7. NEVER assign a language specialist to produce output in a different language than requested.
-- Each agent's task description MUST explicitly state the target language/technology so the agent cannot drift.
-- Only use agent IDs that appear in the roster above. Do not invent agent IDs.
-- Reviewers: always include Q3 for code tasks. Include Q1 for security-sensitive work. Include Q4 for debugging tasks.
-- Enhancer: choose the agent best positioned to elevate the final output quality (often Q3, Q6, or A5).
+## Step 2 — Write agent task descriptions
+Each task description must be a DETAILED BRIEF, not a one-liner. Include:
+- The exact deliverable with scope (e.g., "Write the complete X, covering A, B, and C")
+- Technology/language constraint (e.g., "Use Python 3.11 with FastAPI")
+- Mandatory sections or components the agent must include
+- Quality bar: "Production-ready, complete, no stubs or placeholders"
+- If multi-file: "Deliver as separate complete files, each with full path as header comment"
 
-Return ONLY valid JSON (no markdown, no explanation):
+## Step 3 — Select agents
+- Choose 2–4 agents whose domains cover DISTINCT parts of the request
+- Language enforcement: Python → L1, JavaScript/Node.js/TypeScript → L2, Go → L3, Rust → L4, SQL → L7
+- Only use IDs from the roster above — do not invent IDs
+- Reviewers: Q3 for all code tasks, Q1 for security-sensitive work, Q4 for debugging
+- Enhancer: agent best suited to final quality elevation (A5, Q3, or Q6)
+
+Return ONLY valid JSON (no markdown fence, no explanation):
 {
-  "analysis": "one-sentence summary of what this request needs",
+  "analysis": "2-3 sentence breakdown of what this request needs and what complete looks like",
   "agents": [
-    {"id": "AGENT_ID", "task": "specific task with explicit language/tech constraint"}
+    {"id": "AGENT_ID", "task": "detailed multi-sentence task brief with scope, tech constraint, mandatory components, and quality bar"}
   ],
   "reviewers": ["Q3"],
   "enhancer": "AGENT_ID"
@@ -283,30 +289,29 @@ async function reviewOutputs(
     const reviewPrompt = `## Original Request
 ${userMessage}
 
-## Scoring Rubric (apply strictly — do not be generous)
-- 90–100%: Production-ready, expert-level. Complete, correct, secure, idiomatic. Handles realistic edge cases.
-- 70–89%: Good quality with minor gaps (one missing error case, a style issue). Fully addresses the request.
-- 40–69%: Partially addresses the request, or has meaningful correctness/completeness gaps.
-- 10–39%: Superficially related but fails the core requirement (wrong language, outline instead of implementation, broken logic).
-- 0–9%: Off-topic, dangerous, or completely wrong.
+## Scoring Rubric
+- 90–100%: Expert-level. Complete, correct, secure, idiomatic. Handles realistic edge cases. No gaps.
+- 75–89%: Good but with a specific addressable gap — one missing section, one unhandled error case. Passes with feedback.
+- 50–74%: Partially addresses the request. Missing significant components or depth. FAILS — requires revision.
+- 0–49%: Fails core requirements. Shallow, incomplete, wrong language, broken logic, or security holes. Hard fail.
 
-## Hard Fail Criteria (passed: false, score ≤ 0.30 — enforce without exception)
-An output FAILS automatically if:
-- It uses a different programming language than explicitly requested
-- It is an outline, concept, or architectural plan when runnable code was requested
-- It introduces security vulnerabilities: XSS (user data inserted into HTML without escaping), SQL injection, hardcoded credentials, unvalidated shell inputs
-- It ignores the primary requirement of the task
-- ARCHITECTURE COLLAPSE: A multi-component system (API, backend service, framework app) is delivered as a single monolithic file when it should be a proper multi-file project structure. Example: a FastAPI application with auth, database, services, and routes must NOT be crammed into one main.py — it must be delivered as separate files (config.py, database.py, models.py, services/, routers/, etc.). A single-file delivery of a multi-module system is an automatic hard fail regardless of whether the code runs.
-- ANY file is truncated, uses ellipsis ("..."), or contains stub placeholders ("# add your logic here", "pass", "TODO") where real implementation is required
+## Hard Fail Criteria (score ≤ 0.49, passed: false — no exceptions)
+- Wrong programming language than requested
+- Outline or concept instead of actual implementation
+- Security vulnerability: unescaped user data in HTML/SQL/shell, hardcoded credentials, unvalidated inputs
+- Core requirement ignored or only partially addressed
+- Architecture collapse: multi-component system crammed into one file instead of proper multi-file structure
+- Truncated output: "...", stubs, TODOs, "add your logic here" where real code is required
+- SHALLOW DEPTH: a response that only scratches the surface, omits key details, or wouldn't let the user proceed without asking follow-up questions — this is a fail
 
 ## Agent Outputs to Review
 ${outputSummary}
 
-Evaluate each output against the rubric and hard-fail criteria. Feedback must be specific and actionable — cite the exact issue and what the fix should be.
-Return JSON:
+For each output: score it honestly against the rubric. If it fails, give specific, actionable feedback citing the exact gap and what the fix must include.
+Return JSON only:
 {
   "reviews": [
-    {"agentId": "ID", "passed": true/false, "feedback": "specific actionable feedback with exact issues cited", "score": 0.00}
+    {"agentId": "ID", "passed": true/false, "feedback": "exact issues and what the revision must include", "score": 0.00}
   ]
 }`;
 
@@ -578,30 +583,45 @@ async function assembleOutput(
 ): Promise<string> {
   const outputSummary = agentOutputs.map(o => `### ${o.id} · ${o.name}\n${o.result}`).join('\n\n---\n\n');
 
-  const assemblePrompt = `You are the SLM Orchestrator performing final synthesis. This response goes directly to a senior engineer who will use it in production. There is no room for gaps, stubs, or mediocrity.
+  const assemblePrompt = `You are a world-class senior expert writing the definitive response to this request. You have reviewed research and contributions from specialist agents. Your job is NOT to stitch their outputs together — it is to use their work as reference material and write the best possible answer yourself, from scratch, as the foremost expert in this domain.
 
-## User's Original Request
+## The Request
 ${userMessage}
 
-## All Agent Contributions
-_Listed in order of authority. Entries marked "Highest Authority" or "Validation Fix" override earlier outputs on conflicting points._
-
+## Agent Contributions (your source material — read carefully, then write your own expert response)
 ${outputSummary}
 
-## Expert Assembly Protocol — every point is mandatory
-1. COMPLETENESS: Fully solve what was asked. No TODOs, no "left as an exercise", no unimplemented stubs. Placeholder values (credentials, domain names) should be clearly labeled YOUR_VALUE_HERE only when they are inherently user-specific.
-2. CORRECTNESS: Cross-check all code logic, imports, and API calls. Fix every bug you identify — do not propagate agent errors. Where outputs conflict, use the higher-authority version.
-3. SECURITY: Apply all applicable security practices: escape user-controlled data before inserting into HTML/SQL/shell, use environment variables for credentials, validate at all system boundaries, never expose internal errors to users.
-4. COHERENCE: Strip all agent headers, phase labels, and internal meta-commentary. One voice, no contradictions, no duplicate content.
-5. USABILITY: Structure for immediate use by a developer reading top-to-bottom. Every code block must run as-is. Shell commands must be accurate. Install instructions must match the actual packages used.
-6. AUTHORITY HIERARCHY: Any contribution labeled "Validation Fix — Highest Authority" or "Enhancement" contains final corrections. These MUST be fully incorporated — they represent post-review corrections and override original agent outputs on any point they address.
-7. STRUCTURE PRESERVATION — CRITICAL: If any agent delivered a proper multi-file project structure, you MUST reproduce that full structure in the final output. Never flatten or collapse it. If agent A1 delivered separate files (main.py, config.py, database.py, models.py, etc.) and agent L1 delivered a single file, the multi-file version wins — always adopt the most architecturally complete version. Every file that appeared in any agent's output must appear in the final output, complete and untruncated. Present files in logical dependency order with their full path as a heading.
+## How to produce a high-quality response
 
-Produce the response as if a single senior engineer with 30 years of deep cross-domain expertise wrote it from scratch after reviewing all agent contributions — complete, production-ready, immediately usable.`;
+**Write as the expert, not as the synthesizer.**
+Do not copy-paste agent outputs with headers stripped. Read what they produced, extract the best ideas and correct implementations, then write a single coherent expert response that is better than any individual contribution. Add your own expert context, rationale, and completeness that the agents may have missed.
+
+**Structure for immediate usability.**
+- Lead with what the user needs to know first
+- Use clear headings to organize complex responses
+- Put all code, config, and commands in proper code blocks
+- Present files in logical dependency order if it's a multi-file project
+- End with setup/usage instructions if applicable
+
+**Completeness is non-negotiable.**
+Every aspect of the request must be addressed. If it involves code: every file is complete, every import is present, every function is implemented. If it involves strategy or design: every major dimension is covered with depth. No TODOs, no stubs, no "you would add X here."
+
+**Depth and precision.**
+Go beyond the obvious. Explain the non-obvious decisions. Cover the realistic failure modes. Give the concrete recommendation, not "you could consider." Name the specific version, write the actual value, show the exact command.
+
+**Fix anything wrong.**
+If an agent produced incorrect code, wrong API usage, or a security hole — fix it in your output. Do not propagate errors. You are the last line of quality control.
+
+**Voice and format.**
+- One unified voice, no agent headers or meta-commentary
+- Confident and direct — no hedging, no "it depends" without a concrete follow-up
+- Only include placeholder values (YOUR_API_KEY etc.) when they are genuinely user-specific secrets
+
+Write the complete, expert-level response now:`;
 
   return await aixChatGenerateText_Simple(
     llmId,
-    'You are the SLM Orchestrator. Synthesize agent outputs into a single perfect response.',
+    'You are a world-class senior expert. Write the definitive, comprehensive response. Be thorough, precise, and complete. No hedging, no stubs.',
     assemblePrompt,
     'chat-react-turn',
     'slm-assemble',


### PR DESCRIPTION
## Summary

- Adds a new **Matrix** send-button mode (`slm-content`) that routes through a 7-phase multi-agent pipeline and renders results as collapsible phase accordions inline in the chat message bubble
- No persona files touched - works with any persona, any model
- Self-contained in `src/modules/slm/` - easy to see all touch points

## Touch points

| File | Change |
|------|--------|
| `execute-mode/execute-mode.types.ts` | + `slm-content` mode ID |
| `execute-mode/execute-mode.items.ts` | + menu entry (label / send color) |
| `editors/_handleExecute.ts` | + `case 'slm-content'` routing |
| `editors/slm-tangent.ts` | runner - properly swaps void placeholder for live text fragment |
| `fragments-content/BlockPartText_AutoBlocks.tsx` | `isSLMOutput` detection → `SLMOutputRenderer` |

## New module: `src/modules/slm/`

- **`slm.agents.ts`** - agent roster (A1 Backend Architect, A2 Frontend, L1-L4 language specialists, Q1/Q3/Q4 security/review/debug, Q6 perf, etc.) each with a focused system prompt
- **`slm.pipeline.ts`** - 7-phase orchestration: Plan → Web Research → Parallel Agent Execution → Review → Fix & Revision → Validation → Enhancement → Final Assembly - all using `aixChatGenerateText_Simple`
- **`SLMOutputRenderer.tsx`** - accordion renderer that parses `**Phase N —` markers and renders each phase as a collapsible card with live status indicators

## Rendering

Phase accordions render directly in the chat bubble - no sidebar panel. The void placeholder fragment is replaced with a real text content fragment on the first progress update, then updated in-place so accordion open/close state is preserved across streaming updates.

## Test plan

- [ ] Select **Matrix** from the send-button menu, send any message
- [ ] Phase accordions appear progressively as each phase completes
- [ ] Each phase is independently expandable/collapsible
- [ ] Final Output section appears at completion
- [ ] Works with any persona active (no persona dependency)
- [ ] No ephemeral sidebar banner shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)