### PR TITLE
Code blocks: add markdown preview for .md fenced code

### DIFF
--- a/src/modules/blocks/code/RenderCode.tsx
+++ b/src/modules/blocks/code/RenderCode.tsx
@@ -6,6 +6,7 @@ import { Box, ButtonGroup, Sheet, Typography } from '@mui/joy';
 import ChangeHistoryTwoToneIcon from '@mui/icons-material/ChangeHistoryTwoTone';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import FitScreenIcon from '@mui/icons-material/FitScreen';
+import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
 import HtmlIcon from '@mui/icons-material/Html';
 import NumbersRoundedIcon from '@mui/icons-material/NumbersRounded';
 import ReplayRoundedIcon from '@mui/icons-material/ReplayRounded';
@@ -19,6 +20,7 @@ import { useUIPreferencesStore } from '~/common/stores/store-ui';
 
 import { OVERLAY_BUTTON_RADIUS, OverlayButton, overlayButtonsActiveSx, overlayButtonsClassName, overlayButtonsTopRightSx, overlayGroupWithShadowSx } from '../OverlayButton';
 import { RenderCodeHtmlIFrame } from './code-renderers/RenderCodeHtmlIFrame';
+import { RenderCodeMarkdown } from './code-renderers/RenderCodeMarkdown';
 import { RenderCodeMermaid } from './code-renderers/RenderCodeMermaid';
 import { heuristicIsSVGCode, RenderCodeSVG } from './code-renderers/RenderCodeSVG';
 import { RenderCodeSyntax } from './code-renderers/RenderCodeSyntax';
@@ -152,6 +154,7 @@ function RenderCodeImpl(props: RenderCodeBaseProps & {
   const [fitScreen, setFitScreen] = React.useState(!!props.fitScreen);
   const [htmlReloadKey, setHtmlReloadKey] = React.useState(0);
   const [showHTML, setShowHTML] = React.useState(props.initialShowHTML === true);
+  const [showMarkdown, setShowMarkdown] = React.useState(true);
   const [showMermaid, setShowMermaid] = React.useState(true);
   const [showPlantUML, setShowPlantUML] = React.useState(true);
   const [showSVG, setShowSVG] = React.useState(true);
@@ -204,6 +207,9 @@ function RenderCodeImpl(props: RenderCodeBaseProps & {
   const isHTMLCode = heuristicIsBlockPureHTML(code);
   const renderHTML = isHTMLCode && showHTML;
 
+  const isMdCode = !blockIsPartial && (lcBlockTitle === 'md' || lcBlockTitle === 'markdown' || lcBlockTitle.endsWith('.md'));
+  const renderMarkdown = isMdCode && showMarkdown;
+
   const isMermaidCode = lcBlockTitle === 'mermaid' && !blockIsPartial;
   const renderMermaid = isMermaidCode && showMermaid;
 
@@ -216,7 +222,7 @@ function RenderCodeImpl(props: RenderCodeBaseProps & {
   const renderSVG = isSVGCode && showSVG;
   const canScaleSVG = renderSVG && code.includes('viewBox="');
 
-  const renderSyntaxHighlight = !renderHTML && !renderMermaid && !renderPlantUML && !renderSVG;
+  const renderSyntaxHighlight = !renderHTML && !renderMarkdown && !renderMermaid && !renderPlantUML && !renderSVG;
   const cannotRenderLineNumbers = !renderSyntaxHighlight || showSoftWrap;
   const renderLineNumbers = !cannotRenderLineNumbers && ((showLineNumbers && uiComplexityMode !== 'minimal') || isFullscreen);
 
@@ -323,10 +329,11 @@ function RenderCodeImpl(props: RenderCodeBaseProps & {
         <span style={!isFullscreen ? undefined : _styles.fullscreenSyntaxFix}>
           {/* Renders HTML, or inline SVG, inline plantUML rendered, or highlighted code */}
           {renderHTML ? <RenderCodeHtmlIFrame key={htmlReloadKey} htmlCode={code} isFullscreen={isFullscreen} />
-            : renderMermaid ? <RenderCodeMermaid mermaidCode={code} fitScreen={fitScreen} />
-              : renderSVG ? <RenderCodeSVG svgCode={code} fitScreen={fitScreen} />
-                : (renderPlantUML && (plantUmlSvgData || plantUmlError)) ? <RenderCodePlantUML svgCode={plantUmlSvgData ?? null} error={plantUmlError} fitScreen={fitScreen} />
-                  : <RenderCodeSyntax highlightedSyntaxAsHtml={codeSyntaxHtml} presenterMode={isFullscreen} />}
+            : renderMarkdown ? <RenderCodeMarkdown mdCode={code} />
+              : renderMermaid ? <RenderCodeMermaid mermaidCode={code} fitScreen={fitScreen} />
+                : renderSVG ? <RenderCodeSVG svgCode={code} fitScreen={fitScreen} />
+                  : (renderPlantUML && (plantUmlSvgData || plantUmlError)) ? <RenderCodePlantUML svgCode={plantUmlSvgData ?? null} error={plantUmlError} fitScreen={fitScreen} />
+                    : <RenderCodeSyntax highlightedSyntaxAsHtml={codeSyntaxHtml} presenterMode={isFullscreen} />}
         </span>
 
       </Box>
@@ -354,6 +361,13 @@ function RenderCodeImpl(props: RenderCodeBaseProps & {
                   </OverlayButton>
                 )}
               </ButtonGroup>
+            )}
+
+            {/* Show Markdown Preview */}
+            {isMdCode && (
+              <OverlayButton tooltip={noTooltips ? null : renderMarkdown ? 'Show Code' : 'Show Preview'} variant={renderMarkdown ? 'solid' : 'outlined'} smShadow onClick={() => setShowMarkdown(!showMarkdown)}>
+                <ArticleOutlinedIcon />
+              </OverlayButton>
             )}
 
             {/* SVG, Mermaid, PlantUML -- including a max-out button */}

--- a/src/modules/blocks/code/code-renderers/RenderCodeMarkdown.tsx
+++ b/src/modules/blocks/code/code-renderers/RenderCodeMarkdown.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+import { Box } from '@mui/joy';
+
+import { RenderMarkdown } from '../../markdown/RenderMarkdown';
+
+
+export function RenderCodeMarkdown(props: { mdCode: string }) {
+  return (
+    <Box className='code-container'>
+      <RenderMarkdown content={props.mdCode} />
+    </Box>
+  );
+}


### PR DESCRIPTION
When a code fence has a .md, md, or markdown title, show a rendered markdown preview by default with a toggle to switch back to code view.

Closes #1126

Generated with [Claude Code](https://claude.ai/code)