### PR TITLE
Code blocks: use existing DescriptionOutlined icon for markdown preview

### DIFF
--- a/src/modules/blocks/code/RenderCode.tsx
+++ b/src/modules/blocks/code/RenderCode.tsx
@@ -6,7 +6,7 @@ import { Box, ButtonGroup, Sheet, Typography } from '@mui/joy';
 import ChangeHistoryTwoToneIcon from '@mui/icons-material/ChangeHistoryTwoTone';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import FitScreenIcon from '@mui/icons-material/FitScreen';
-import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import HtmlIcon from '@mui/icons-material/Html';
 import NumbersRoundedIcon from '@mui/icons-material/NumbersRounded';
 import ReplayRoundedIcon from '@mui/icons-material/ReplayRounded';
@@ -366,7 +366,7 @@ function RenderCodeImpl(props: RenderCodeBaseProps & {
             {/* Show Markdown Preview */}
             {isMdCode && (
               <OverlayButton tooltip={noTooltips ? null : renderMarkdown ? 'Show Code' : 'Show Preview'} variant={renderMarkdown ? 'solid' : 'outlined'} smShadow onClick={() => setShowMarkdown(!showMarkdown)}>
-                <ArticleOutlinedIcon />
+                <DescriptionOutlinedIcon />
               </OverlayButton>
             )}
 


### PR DESCRIPTION
Replace `ArticleOutlinedIcon` (newly introduced) with `DescriptionOutlinedIcon` which is already used in the codebase for document representation.

Closes #1126

Generated with [Claude Code](https://claude.ai/code)