### PR TITLE
LLMs: openai-autocomplete: add EmpirioLabs

### DIFF
--- a/src/modules/llms/vendors/openai/OpenAIHostAutocomplete.tsx
+++ b/src/modules/llms/vendors/openai/OpenAIHostAutocomplete.tsx
@@ -40,6 +40,7 @@ const OPENAI_COMPATIBLE_PROVIDERS: VerifiedProvider[] = [
   // Example Providers
   { id: 'arcee', label: 'Arcee AI', host: 'https://api.arcee.ai/api', hostMatch: 'arcee.ai', category: 'Example Providers', description: 'Open-weight MoE models', docsUrl: 'https://docs.arcee.ai/', icon: ArceeAIIcon },
   { id: 'chutes', label: 'Chutes AI', host: 'https://llm.chutes.ai', hostMatch: '.chutes.ai', category: 'Example Providers', description: 'Serverless open model inference', docsUrl: 'https://chutes.ai/docs', icon: ChutesAIIcon },
+  { id: 'empiriolabs', label: 'EmpirioLabs', host: 'https://api.empiriolabs.ai', hostMatch: 'empiriolabs.ai', category: 'Example Providers', description: 'Multi-model API platform', docsUrl: 'https://docs.empiriolabs.ai' },
   { id: 'fireworks', label: 'Fireworks AI', host: 'https://api.fireworks.ai/inference', hostMatch: 'fireworks.ai', category: 'Example Providers', description: 'Fast open model inference', docsUrl: 'https://docs.fireworks.ai/getting-started/quickstart', icon: FireworksAIIcon },
   { id: 'llmapi', label: 'LLM API', host: 'https://api.llmapi.ai', hostMatch: 'llmapi.ai', category: 'Example Providers', description: 'Multi-provider API gateway', docsUrl: 'https://llmapi.ai' },
   { id: 'minimax', label: 'MiniMax', host: 'https://api.minimax.io', hostMatch: 'minimax.io', category: 'Example Providers', description: 'Proprietary reasoning models', docsUrl: 'https://platform.minimax.io/docs', icon: MiniMaxIcon },


### PR DESCRIPTION
Adds EmpirioLabs to `OPENAI_COMPATIBLE_PROVIDERS` per the triage assessment in #1129: one icon-less entry matching the LLM API shape, placed alphabetically between Chutes AI and Fireworks AI.

EmpirioLabs serves an OpenAI-compatible Chat Completions API (streaming, `/v1/models` catalog) and already works through the OpenAI provider with a custom host; this is purely a named discoverability entry.

Closes #1129