### PR TITLE
Diagrams: skip IME composition Enter in custom instruction

### DIFF
--- a/src/modules/aifn/digrams/DiagramsModal.tsx
+++ b/src/modules/aifn/digrams/DiagramsModal.tsx
@@ -145,6 +145,9 @@ export function DiagramsModal(props: { config: DiagramConfig, onClose: () => voi
 
   const handleCustomInstructionKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
+      // Skip if composing (e.g., CJK input methods) - issue #784
+      if (event.nativeEvent.isComposing)
+        return;
       event.preventDefault();
       void handleGenerateNew();
     }


### PR DESCRIPTION
The Custom Instruction input in the Diagrams modal regenerates on Enter, but it doesn't skip the Enter that commits an IME composition. When the instruction is typed in Chinese / Japanese / Korean, the Enter that confirms the conversion also fires a regenerate, using the text that is still being composed.

This is the same problem as #784, which #916 fixed for the composer by checking `event.nativeEvent.isComposing`. The custom instruction field was added later (#280) and wasn't covered by that fix, so it kept the old behavior. This applies the same guard:

```ts
// Skip if composing (e.g., CJK input methods) - issue #784
if (event.nativeEvent.isComposing)
  return;
```

I kept it to the single `isComposing` check the existing guards use (Composer / InlineTextarea / BlockEdit_TextFragment / PromptComposer). For non-IME input `isComposing` is `false`, so normal typing is unchanged.

I confirmed it compiles; I don't have an IME set up to run the full manual repro, so a second check there would be welcome.
