### PR TITLE
T2I: OpenRouter: add image generation via the dedicated Image API

### DIFF
--- a/src/apps/draw/create/DrawProviderConfigure.tsx
+++ b/src/apps/draw/create/DrawProviderConfigure.tsx
@@ -5,6 +5,7 @@ import { Box, Button, Card, CardContent } from '@mui/joy';
 import ConstructionIcon from '@mui/icons-material/Construction';
 
 import { DallESettings } from '~/modules/t2i/dalle/DallESettings';
+import { OpenRouterT2ISettings } from '~/modules/t2i/openrouter/OpenRouterT2ISettings';
 
 import type { TextToImageProvider } from '~/common/components/useCapabilities';
 import { ExpanderControlledBox } from '~/common/components/ExpanderControlledBox';
@@ -29,7 +30,7 @@ export function DrawProviderConfigure(props: {
 
   const { ProviderConfig } = React.useMemo(() => {
     const provider = providers.find(provider => provider.providerId === activeProviderId);
-    const ProviderConfig: React.FC | null = provider?.vendor === 'openai' ? DallESettings : null;
+    const ProviderConfig: React.FC | null = provider?.vendor === 'openai' ? DallESettings : provider?.vendor === 'openrouter' ? OpenRouterT2ISettings : null;
     return {
       ProviderConfig,
     };

--- a/src/apps/draw/create/DrawProviderSelector.tsx
+++ b/src/apps/draw/create/DrawProviderSelector.tsx
@@ -7,6 +7,7 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 
 import type { TextToImageProvider } from '~/common/components/useCapabilities';
 import { OpenAIIcon } from '~/common/components/icons/vendors/OpenAIIcon';
+import { OpenRouterIcon } from '~/common/components/icons/vendors/OpenRouterIcon';
 import { hideOnMobile } from '~/common/app.theme';
 import { optimaSelectSlotProps } from '~/common/layout/optima/bar/OptimaBarDropdown';
 
@@ -27,7 +28,7 @@ export function DrawProviderSelector(props: {
         label: provider.label + (provider.painter !== provider.label ? ` ${provider.painter}` : ''),
         value: provider.providerId,
         configured: provider.configured,
-        Icon: provider.vendor === 'openai' ? OpenAIIcon : FormatPaintTwoToneIcon,
+        Icon: provider.vendor === 'openai' ? OpenAIIcon : provider.vendor === 'openrouter' ? OpenRouterIcon : FormatPaintTwoToneIcon,
       });
     });
     return options;

--- a/src/apps/settings-modal/SettingsContent.tsx
+++ b/src/apps/settings-modal/SettingsContent.tsx
@@ -12,6 +12,7 @@ import { ASRxConfigureEngines } from '~/modules/asrx/components/ASRxConfigureEng
 import { BrowseSettings } from '~/modules/browse/BrowseSettings';
 import { DallESettings } from '~/modules/t2i/dalle/DallESettings';
 import { GoogleSearchSettings } from '~/modules/google/GoogleSearchSettings';
+import { OpenRouterT2ISettings } from '~/modules/t2i/openrouter/OpenRouterT2ISettings';
 import { T2ISettings } from '~/modules/t2i/T2ISettings';
 
 import type { SettingsNavId } from './settings.nav';
@@ -195,12 +196,14 @@ function renderSection(nodeId: SettingsNavId, isMobile: boolean, onSelect: (id: 
     case 'voice-out':
       return <VoiceOutputBlock isMobile={isMobile} />;
 
-    // Draw: flat, provider picker then provider-specific (OpenAI) settings
+    // Draw: flat, provider picker then provider-specific (OpenAI, OpenRouter) settings
     case 'draw':
       return <>
         <Box sx={_styles.block}><T2ISettings /></Box>
         <SectionHeader label='OpenAI' />
         <Box sx={_styles.block}><DallESettings /></Box>
+        <SectionHeader label='OpenRouter' />
+        <Box sx={_styles.block}><OpenRouterT2ISettings /></Box>
       </>;
 
     // Tools parent (hub): common search info, then links into Browsing / Custom Search

--- a/src/common/components/useCapabilities.ts
+++ b/src/common/components/useCapabilities.ts
@@ -39,7 +39,7 @@ export interface TextToImageProvider {
   configured: boolean;
 }
 
-type TextToImageVendor = Extract<ModelVendorId, 'azure' | 'openai' | 'localai' | 'googleai' | 'xai'>;
+type TextToImageVendor = Extract<ModelVendorId, 'azure' | 'openai' | 'localai' | 'googleai' | 'openrouter' | 'xai'>;
 
 export interface CapabilityTextToImage {
   mayWork: boolean;

--- a/src/modules/llms/server/openai/openai.access.ts
+++ b/src/modules/llms/server/openai/openai.access.ts
@@ -60,6 +60,12 @@ export const OPENAI_API_PATHS = {
   xaiLanguageModels: '/v1/language-models',
 } as const;
 
+// -- OpenRouter-specific API Paths --
+
+export const OPENROUTER_API_PATHS = {
+  images: '/v1/images', // dedicated image generation endpoint, not OpenAI-compatible
+} as const;
+
 
 /** Select a random key from a comma-separated list of API keys, used to load balance. */
 export function llmsRandomKeyFromMultiKey(multiKeyString: string): string {

--- a/src/modules/llms/server/openai/openai.router.ts
+++ b/src/modules/llms/server/openai/openai.router.ts
@@ -5,16 +5,17 @@ import { createTRPCRouter, edgeProcedure } from '~/server/trpc/trpc.server';
 import { fetchJsonOrTRPCThrow, fetchResponseOrTRPCThrow, TRPCFetcherError } from '~/server/trpc/trpc.router.fetchers';
 import { serverCapitalizeFirstLetter } from '~/server/wire';
 
-import type { T2ICreateImageAsyncStreamOp } from '~/modules/t2i/t2i.server';
+import { getImageInformationFromBytes, type T2ICreateImageAsyncStreamOp } from '~/modules/t2i/t2i.server';
 import { OpenAIWire_API_Images_Generations } from '~/modules/aix/server/dispatch/wiretypes/openai.wiretypes';
 import { heartbeatsWhileAwaiting } from '~/modules/aix/server/dispatch/heartbeatsWhileAwaiting';
 
 import { wireLocalAIModelsApplyOutputSchema, wireLocalAIModelsAvailableOutputSchema, wireLocalAIModelsListOutputSchema } from './wiretypes/localai.wiretypes';
+import { WireOpenRouterCreateImagesRequest, wireOpenRouterCreateImagesResponseSchema } from './wiretypes/openrouter.wiretypes';
 
 import { ListModelsResponse_schema, ModelDescriptionSchema } from '../llm.server.types';
 import { listModelsRunDispatch } from '../listModels.dispatch';
 
-import { openAIAccess, OpenAIAccessSchema, openAIAccessSchema, OPENAI_API_PATHS } from './openai.access';
+import { openAIAccess, OpenAIAccessSchema, openAIAccessSchema, OPENAI_API_PATHS, OPENROUTER_API_PATHS } from './openai.access';
 
 
 // Router Input/Output Schemas
@@ -318,6 +319,93 @@ export const llmOpenAIRouter = createTRPCRouter({
 
 
   // --- Dialect-specific procedures ---
+
+  /* [OpenRouter] images generation - dedicated endpoint, different path and wire format than OpenAI */
+  dialectOpenRouter_createImages: edgeProcedure
+    .input(z.object({
+      access: openAIAccessSchema,
+      generationConfig: z.object({
+        model: z.string(),
+        prompt: z.string(),
+        count: z.number().min(1).max(10),
+      }),
+    }))
+    .mutation(async function* ({ input, signal }): AsyncGenerator<T2ICreateImageAsyncStreamOp> {
+
+      const { access, generationConfig: config } = input;
+
+      // -> state.started
+      yield { p: 'state', state: 'started' };
+
+      // -> heartbeats, while waiting for the generation response
+      const wireResponse = yield* heartbeatsWhileAwaiting(
+        openaiPOSTOrThrow<object, WireOpenRouterCreateImagesRequest>(
+          access,
+          config.model,
+          {
+            model: config.model,
+            prompt: config.prompt,
+            ...(config.count > 1 && { n: config.count }),
+          },
+          OPENROUTER_API_PATHS.images,
+          signal,
+        )
+          .catch((error: any) => {
+            // if aborted, ignore the error, or else we'll throw an error
+            if (signal?.aborted)
+              return null; // de-facto ignores the error, and the connection is already gone
+
+            // otherwise, re-throw the error
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: `Error: ${error?.message || error?.toString() || 'Unknown error'}`,
+              cause: error,
+            });
+          }),
+      );
+
+      // null: there was an error
+      if (!wireResponse)
+        return null;
+
+      // parse the response and emit all images in the response
+      const { data: images, usage } = wireOpenRouterCreateImagesResponseSchema.parse(wireResponse);
+      for (const image of images) {
+
+        // b64_json is raw base64 and media_type may be absent - sniff the mime type and dimensions from the bytes
+        const imageBytes = Buffer.from(image.b64_json, 'base64');
+        let mimeType = image.media_type || 'image/png';
+        let width = 0;
+        let height = 0;
+        try {
+          const info = getImageInformationFromBytes(imageBytes.buffer.slice(imageBytes.byteOffset, imageBytes.byteOffset + imageBytes.byteLength) as ArrayBuffer);
+          mimeType = info.mimeType;
+          width = info.width;
+          height = info.height;
+        } catch (error) {
+          // unsupported format (e.g. WebP) - keep the media_type (or default) and unknown dimensions
+          console.log(`openai.router.dialectOpenRouter_createImages: could not sniff image (${mimeType})`, error);
+        }
+
+        // -> createImage
+        yield {
+          p: 'createImage',
+          image: {
+            mimeType,
+            base64Data: image.b64_json,
+            altText: image.revised_prompt || config.prompt,
+            width,
+            height,
+            ...(usage?.prompt_tokens !== undefined ? { inputTokens: usage.prompt_tokens } : {}),
+            ...(usage?.completion_tokens !== undefined ? { outputTokens: usage.completion_tokens } : {}),
+            generatorName: config.model,
+            parameters: { model: config.model },
+            generatedAt: new Date().toISOString(),
+          },
+        };
+      }
+    }),
+
 
   /* [LocalAI] List all Model Galleries */
   dialectLocalAI_galleryModelsAvailable: edgeProcedure

--- a/src/modules/llms/server/openai/openai.router.ts
+++ b/src/modules/llms/server/openai/openai.router.ts
@@ -384,7 +384,7 @@ export const llmOpenAIRouter = createTRPCRouter({
           height = info.height;
         } catch (error) {
           // unsupported format (e.g. WebP) - keep the media_type (or default) and unknown dimensions
-          console.log(`openai.router.dialectOpenRouter_createImages: could not sniff image (${mimeType})`, error);
+          console.warn(`openai.router.dialectOpenRouter_createImages: could not sniff image (${mimeType})`, error);
         }
 
         // -> createImage

--- a/src/modules/llms/server/openai/wiretypes/openrouter.wiretypes.ts
+++ b/src/modules/llms/server/openai/wiretypes/openrouter.wiretypes.ts
@@ -97,3 +97,28 @@ export const wireOpenrouterModelsListOutputSchema = z.object({
   // }).nullish(),
 
 });
+
+// [OpenRouter] Image Generation API - https://openrouter.ai/docs/features/multimodal/image-generation
+// - POST /api/v1/images: { model, prompt, n? } -> { created, data: [{ b64_json, media_type? }], usage? }
+
+export type WireOpenRouterCreateImagesRequest = z.infer<typeof wireOpenRouterCreateImagesRequestSchema>;
+export const wireOpenRouterCreateImagesRequestSchema = z.object({
+  model: z.string(),
+  prompt: z.string(),
+  n: z.number().min(1).max(10).optional(),
+});
+
+export type WireOpenRouterCreateImagesResponse = z.infer<typeof wireOpenRouterCreateImagesResponseSchema>;
+export const wireOpenRouterCreateImagesResponseSchema = z.object({
+  created: z.number().optional(),
+  data: z.array(z.object({
+    b64_json: z.string(),
+    media_type: z.string().optional(), // e.g. 'image/png' - may be absent even for JPEGs
+    revised_prompt: z.string().optional(),
+  })),
+  usage: z.object({
+    prompt_tokens: z.number().optional(),
+    completion_tokens: z.number().optional(),
+    total_tokens: z.number().optional(),
+  }).loose().optional(),
+});

--- a/src/modules/t2i/openrouter/OpenRouterT2ISettings.tsx
+++ b/src/modules/t2i/openrouter/OpenRouterT2ISettings.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+
+import { FormControl, Option, Select } from '@mui/joy';
+
+import { FormLabelStart } from '~/common/components/forms/FormLabelStart';
+import { Link } from '~/common/components/Link';
+
+import { OPENROUTER_IMAGE_MODELS, useOpenRouterT2IStore } from './store-module-openrouter';
+
+
+export function OpenRouterT2ISettings() {
+
+  // external state
+  const { orImageModelId, setOrImageModelId } = useOpenRouterT2IStore();
+
+  return <>
+
+    <FormControl orientation='horizontal' sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
+      <FormLabelStart
+        title='Model'
+        description={<Link level='body-sm' href='https://openrouter.ai/models?fmt=cards&output_modalities=image' target='_blank'>Image models</Link>}
+      />
+      <Select
+        value={orImageModelId}
+        onChange={(_event, value) => value && setOrImageModelId(value)}
+        slotProps={{ button: { sx: { whiteSpace: 'inherit' } } }}
+        sx={{ minWidth: '10rem' }}
+      >
+        {OPENROUTER_IMAGE_MODELS.map(option => (
+          <Option key={option.value} value={option.value}>
+            {option.label}
+          </Option>
+        ))}
+      </Select>
+    </FormControl>
+
+  </>;
+}

--- a/src/modules/t2i/openrouter/openrouterGenerateImages.ts
+++ b/src/modules/t2i/openrouter/openrouterGenerateImages.ts
@@ -20,6 +20,7 @@ export async function openRouterGenerateImagesOrThrow(
 
   // Use the current settings
   const { orImageModelId } = useOpenRouterT2IStore.getState();
+  const transportAccess = findServiceAccessOrThrow<{}, OpenAIAccessSchema>(modelServiceIdForAccess).transportAccess;
 
   // helper to check for abort conditions and throw consistent error
   function throwIfAborted(error?: any) {
@@ -33,33 +34,65 @@ export async function openRouterGenerateImagesOrThrow(
     }
   }
 
-  throwIfAborted(); // Check before starting
+  // Generate a single image per request. Most OpenRouter image models only support n=1
+  // (all Gemini/FLUX/MAI/Riverflow models cap at 1), so we fan out `count` parallel
+  // single-image requests rather than relying on `n` - same approach the DALL·E 3 path uses.
+  async function generateSingleImage(): Promise<T2iCreateImageOutput[]> {
+    throwIfAborted(); // Check before starting
 
-  // we use an async generator to stream heartbeat events while waiting for the images
-  const operations = await apiStream.llmOpenAI.dialectOpenRouter_createImages.mutate({
-    access: findServiceAccessOrThrow<{}, OpenAIAccessSchema>(modelServiceIdForAccess).transportAccess,
-    generationConfig: {
-      model: orImageModelId,
-      prompt,
-      count,
-    },
-  }, {
-    signal: abortSignal, // aborts the tRPC request
-  });
+    // we use an async generator to stream heartbeat events while waiting for the image
+    const operations = await apiStream.llmOpenAI.dialectOpenRouter_createImages.mutate({
+      access: transportAccess,
+      generationConfig: {
+        model: orImageModelId,
+        prompt,
+        count: 1,
+      },
+    }, {
+      signal: abortSignal, // aborts the tRPC request
+    });
 
-  const createdImages: T2iCreateImageOutput[] = [];
-  try {
-    for await (const op of operations) {
-      throwIfAborted(); // Check during iteration
-      if (op.p === 'createImage')
-        createdImages.push(op.image);
+    const createdImages: T2iCreateImageOutput[] = [];
+    try {
+      for await (const op of operations) {
+        throwIfAborted(); // Check during iteration
+        if (op.p === 'createImage')
+          createdImages.push(op.image);
+      }
+    } catch (error: any) {
+      throwIfAborted(error);
+      throw error; // Re-throw non-abort errors
     }
-  } catch (error: any) {
-    throwIfAborted(error);
-    // surface the server error message if available
-    const message = error?.shape?.message || error?.message || '';
-    throw new Error(`OpenRouter image generation: ${message || 'Unknown error'}`);
+
+    return createdImages;
   }
 
-  return createdImages;
+  // Run all single-image requests in parallel and handle all results
+  const batchResults = await Promise.allSettled(Array.from({ length: count }, () => generateSingleImage()));
+
+  // Throw if ALL requests were rejected
+  const allRejected = batchResults.every(result => result.status === 'rejected');
+  if (allRejected) {
+
+    // preserve the abort nature if the first rejection was an abort
+    const firstError = (batchResults.find(result => result.status === 'rejected') as PromiseRejectedResult | undefined)?.reason;
+    if (firstError?.name === 'AbortError')
+      throw firstError;
+
+    // surface the server error message(s) if available
+    const errorMessages = batchResults
+      .map(result => {
+        const reason = (result as PromiseRejectedResult).reason as any; // TRPCClientError<TRPCErrorShape>
+        return reason?.shape?.message || reason?.message || '';
+      })
+      .filter(message => !!message)
+      .join(', ');
+    throw new Error(`OpenRouter image generation: ${errorMessages || 'Unknown error'}`);
+  }
+
+  // Take successful results and return as a flat array
+  return batchResults
+    .filter(result => result.status === 'fulfilled')
+    .map(result => (result as PromiseFulfilledResult<T2iCreateImageOutput[]>).value)
+    .flat();
 }

--- a/src/modules/t2i/openrouter/openrouterGenerateImages.ts
+++ b/src/modules/t2i/openrouter/openrouterGenerateImages.ts
@@ -1,0 +1,65 @@
+import type { DModelsServiceId } from '~/common/stores/llms/llms.service.types';
+import { apiStream } from '~/common/util/trpc.client';
+
+import type { OpenAIAccessSchema } from '~/modules/llms/server/openai/openai.access';
+import { findServiceAccessOrThrow } from '~/modules/llms/vendors/vendor.helpers';
+
+import type { T2iCreateImageOutput, T2iGenerateOptions } from '../t2i.server';
+import { useOpenRouterT2IStore } from './store-module-openrouter';
+
+
+/**
+ * Client function to call the OpenRouter image generation API (dedicated /api/v1/images endpoint).
+ */
+export async function openRouterGenerateImagesOrThrow(
+  modelServiceIdForAccess: DModelsServiceId,
+  prompt: string,
+  count: number,
+  { abortSignal }: T2iGenerateOptions = {},
+): Promise<T2iCreateImageOutput[]> {
+
+  // Use the current settings
+  const { orImageModelId } = useOpenRouterT2IStore.getState();
+
+  // helper to check for abort conditions and throw consistent error
+  function throwIfAborted(error?: any) {
+    if (abortSignal?.aborted ||
+      error?.name === 'AbortError' ||
+      error?.message?.includes('aborted') ||
+      error?.message?.includes('BodyStreamBuffer was aborted')) {
+      const abortError = new Error('Image generation was cancelled');
+      abortError.name = 'AbortError';
+      throw abortError;
+    }
+  }
+
+  throwIfAborted(); // Check before starting
+
+  // we use an async generator to stream heartbeat events while waiting for the images
+  const operations = await apiStream.llmOpenAI.dialectOpenRouter_createImages.mutate({
+    access: findServiceAccessOrThrow<{}, OpenAIAccessSchema>(modelServiceIdForAccess).transportAccess,
+    generationConfig: {
+      model: orImageModelId,
+      prompt,
+      count,
+    },
+  }, {
+    signal: abortSignal, // aborts the tRPC request
+  });
+
+  const createdImages: T2iCreateImageOutput[] = [];
+  try {
+    for await (const op of operations) {
+      throwIfAborted(); // Check during iteration
+      if (op.p === 'createImage')
+        createdImages.push(op.image);
+    }
+  } catch (error: any) {
+    throwIfAborted(error);
+    // surface the server error message if available
+    const message = error?.shape?.message || error?.message || '';
+    throw new Error(`OpenRouter image generation: ${message || 'Unknown error'}`);
+  }
+
+  return createdImages;
+}

--- a/src/modules/t2i/openrouter/store-module-openrouter.ts
+++ b/src/modules/t2i/openrouter/store-module-openrouter.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+
+// NOTE: starter set of image generation models available through the OpenRouter
+//       dedicated image API (POST /api/v1/images). The full list is at
+//       https://openrouter.ai/models?fmt=cards&output_modalities=image
+
+export const OPENROUTER_IMAGE_MODELS: { value: string, label: string }[] = [
+  { value: 'google/gemini-3-pro-image', label: 'Gemini 3 Pro Image (Nano Banana Pro)' },
+  { value: 'google/gemini-3.1-flash-image', label: 'Gemini 3.1 Flash Image' },
+  { value: 'google/gemini-2.5-flash-image', label: 'Gemini 2.5 Flash Image (Nano Banana)' },
+  { value: 'openai/gpt-image-2', label: 'GPT Image 2' },
+  { value: 'openai/gpt-image-1-mini', label: 'GPT Image 1 Mini' },
+  { value: 'black-forest-labs/flux.2-max', label: 'FLUX.2 Max' },
+  { value: 'black-forest-labs/flux.2-pro', label: 'FLUX.2 Pro' },
+  { value: 'bytedance-seed/seedream-4.5', label: 'Seedream 4.5' },
+  { value: 'microsoft/mai-image-2.5', label: 'MAI Image 2.5' },
+  { value: 'recraft/recraft-v4', label: 'Recraft V4' },
+  { value: 'sourceful/riverflow-v2.5-pro', label: 'Riverflow V2.5 Pro' },
+];
+
+export const OPENROUTER_DEFAULT_IMAGE_MODEL = 'google/gemini-2.5-flash-image';
+
+
+export function openRouterImageModelLabel(modelId: string): string {
+  return OPENROUTER_IMAGE_MODELS.find(m => m.value === modelId)?.label || modelId;
+}
+
+
+interface ModuleOpenRouterT2IStore {
+
+  orImageModelId: string;
+  setOrImageModelId: (modelId: string) => void;
+
+}
+
+export const useOpenRouterT2IStore = create<ModuleOpenRouterT2IStore>()(
+  persist(
+    (set) => ({
+
+      orImageModelId: OPENROUTER_DEFAULT_IMAGE_MODEL,
+      setOrImageModelId: (orImageModelId) => set({ orImageModelId }),
+
+    }),
+    {
+      name: 'app-module-openrouter-t2i',
+      version: 1,
+    },
+  ),
+);

--- a/src/modules/t2i/t2i.client.ts
+++ b/src/modules/t2i/t2i.client.ts
@@ -19,6 +19,8 @@ import { shallowEquals } from '~/common/util/hooks/useShallowObject';
 
 import type { T2iCreateImageOutput, T2iGenerateOptions } from './t2i.server';
 import { openAIGenerateImagesOrThrow, openAIImageModelsCurrentGeneratorName } from './dalle/openaiGenerateImages';
+import { openRouterGenerateImagesOrThrow } from './openrouter/openrouterGenerateImages';
+import { openRouterImageModelLabel, useOpenRouterT2IStore } from './openrouter/store-module-openrouter';
 import { useTextToImageStore } from './store-module-t2i';
 
 
@@ -43,6 +45,8 @@ export function useCapabilityTextToImage(): CapabilityTextToImage {
 
   const dalleModelId = useDalleStore(state => state.dalleModelId);
 
+  const orImageModelId = useOpenRouterT2IStore(state => state.orImageModelId);
+
 
   // memo
 
@@ -59,7 +63,8 @@ export function useCapabilityTextToImage(): CapabilityTextToImage {
       providers,
       activeProvider,
     };
-  }, [userProviderId, dalleModelId, llmsModelServices]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userProviderId, dalleModelId, orImageModelId, llmsModelServices]);
 
 
   return {
@@ -118,6 +123,13 @@ export async function t2iGenerateImagesOrThrow(
 
     case 'googleai':
       throw new Error('Gemini Imagen integration coming soon');
+
+    case 'openrouter':
+      if (!modelServiceId)
+        throw new Error('No OpenRouter Model service configured for TextToImage');
+      if (aixInlineImageParts?.length)
+        throw new Error('Image transformation is not yet available with OpenRouter. Please use an OpenAI service instead.');
+      return await openRouterGenerateImagesOrThrow(modelServiceId, prompt, count, options);
 
     case 'xai':
       throw new Error('xAI image generation integration coming soon');
@@ -207,8 +219,8 @@ interface T2ILlmsModelService {
 function _findLlmsT2IServices(llms: ReadonlyArray<DLLM>, services: ReadonlyArray<DModelsService>) {
   return services
     .filter(s => {
-      // allowlist azure and localai
-      if (s.vId === 'azure' || s.vId === 'localai') return true;
+      // allowlist azure, localai and openrouter
+      if (s.vId === 'azure' || s.vId === 'localai' || s.vId === 'openrouter') return true;
       // denylist non-openai
       if (s.vId !== 'openai') return false;
       // openai: skip OpenAI-compatible proxies (MiniMax, ChutesAI, Fireworks, ...)
@@ -252,6 +264,19 @@ function _getTextToImageProviders(llmsModelServices: T2ILlmsModelService[]) {
           label,
           painter: openAIImageModelsCurrentGeneratorName(), // sync this with dMessageUtils.tsx
           description: 'OpenAI Image generation models',
+          configured: hasAnyModels,
+        });
+        break;
+
+      case 'openrouter':
+        providers.push({
+          providerId: modelServiceId, // identity mapping here
+          modelServiceId,
+          vendor: 'openrouter',
+          priority: 40, // below direct OpenAI configs
+          label,
+          painter: openRouterImageModelLabel(useOpenRouterT2IStore.getState().orImageModelId),
+          description: 'OpenRouter Image generation models',
           configured: hasAnyModels,
         });
         break;


### PR DESCRIPTION
## Motivation

OpenRouter recently launched a dedicated image generation endpoint (`POST /api/v1/images` — [docs](https://openrouter.ai/docs/features/multimodal/image-generation)). This lets big-AGI users generate images with the many image models available on OpenRouter (Gemini Image / Nano Banana, GPT Image, FLUX.2, Seedream, Recraft, Riverflow, MAI, ...) through a single OpenRouter key — the same one already configured for chat. Today big-AGI has OpenAI/Azure/LocalAI T2I providers, but no way to draw through OpenRouter.

## Implementation

Follows the existing T2I provider pattern (DALL·E is the reference):

- **Server**: new `dialectOpenRouter_createImages` streaming procedure in `openai.router.ts` (heartbeats while awaiting, same as `createImages`), posting `{ model, prompt, n? }` to `/v1/images` via the existing `openrouter` access dialect (so `OPENROUTER_API_KEY` server env and client-configured keys both work). Response wiretype (`{ created, data: [{ b64_json, media_type? }], usage? }`) added to `openrouter.wiretypes.ts`. Since `media_type` can be absent (and is sometimes inaccurate), the mime type and dimensions are sniffed from the decoded bytes with the existing `getImageInformationFromBytes` helper, falling back to `media_type`/png for formats it doesn't know (e.g. WebP).
- **Client**: new `src/modules/t2i/openrouter/` module — generation client, a small persisted store for the selected image model, and a settings panel with a starter model list (the full catalog is linked). OpenRouter services are picked up by `_findLlmsT2IServices` / `_getTextToImageProviders`, and the `openrouter` vendor is wired into `t2iGenerateImagesOrThrow`.
- **UI**: model selector appears in Draw > Options and in Preferences > Draw; the Draw service selector shows the OpenRouter icon.

Not included (kept minimal): image-to-image (the endpoint supports it via `images[]`, but wiring the edit path is a natural follow-up), per-model size/quality options, dynamic model listing from `/api/v1/models?output_modalities=image`.

## Testing

- `tsc --noEmit` and `eslint` clean on all touched files.
- Manually tested end-to-end against the live OpenRouter API with a real key: generated images through the Draw app UI (service selector → prompt → Draw), verified the image renders in the Gallery with correct origin metadata (`generatorName: google/gemini-2.5-flash-image`, 1024x1024, `image/png` sniffed from bytes, input/output token usage populated), and verified abort/error paths return readable messages.
- Also exercised the tRPC route directly (batched jsonl streaming) to confirm the heartbeat + `createImage` op flow.

Happy to adjust the starter model list, naming, or move the model selection elsewhere — opening as draft for direction.
