### PR TITLE
feat(llms): add DaoXE OpenAI-compatible dynamic backend

### DIFF
--- a/src/common/components/icons/vendors/DaoXEIcon.tsx
+++ b/src/common/components/icons/vendors/DaoXEIcon.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+import { SvgIcon, SvgIconProps } from '@mui/joy';
+
+/** Monochrome mark for DaoXE dynamic OpenAI-compatible backend detection. */
+export function DaoXEIcon(props: SvgIconProps) {
+  return (
+    <SvgIcon viewBox='0 0 24 24' width='24' height='24' fill='currentColor' stroke='none' {...props}>
+      {/* Stylized "D" gateway mark */}
+      <path d='M4 4h8c4.4 0 8 3.6 8 8s-3.6 8-8 8H4V4zm3.2 3.2v9.6H12c2.65 0 4.8-2.15 4.8-4.8S14.65 7.2 12 7.2H7.2z' />
+      <path d='M6 11h12v2H6z' opacity='0.35' />
+    </SvgIcon>
+  );
+}

--- a/src/modules/llms/server/listModels.dispatch.ts
+++ b/src/modules/llms/server/listModels.dispatch.ts
@@ -39,6 +39,7 @@ import { cerebrasFetchModelDescriptions } from './openai/models/cerebras.models'
 import { chutesAIHeuristic, chutesAIModelsToModelDescriptions } from './openai/models/chutesai.models';
 import { cohereModelFilter, cohereModelSort, cohereModelToModelDescription } from './openai/models/cohere.models';
 import { deepseekModelFilter, deepseekModelSort, deepseekModelToModelDescription } from './openai/models/deepseek.models';
+import { daoxeHeuristic, daoxeModelsToModelDescriptions } from './openai/models/daoxe.models';
 import { fastAPIHeuristic, fastAPIModels } from './openai/models/fastapi.models';
 import { fireworksAIHeuristic, fireworksAIModelsToModelDescriptions } from './openai/models/fireworksai.models';
 import { groqModelFilter, groqModelSortFn, groqModelToModelDescription, groqValidateModelDefs_DEV } from './openai/models/groq.models';
@@ -501,6 +502,10 @@ function _listModelsCreateDispatch(access: AixAPI_Access, signal?: AbortSignal):
               // [ChutesAI] special case for model enumeration
               if (chutesAIHeuristic(oaiUrl))
                 return chutesAIModelsToModelDescriptions(maybeModels);
+
+              // [DaoXE] multi-model multi-protocol gateway
+              if (daoxeHeuristic(oaiUrl))
+                return daoxeModelsToModelDescriptions(maybeModels);
 
               // [FireworksAI] special case for model enumeration
               if (fireworksAIHeuristic(oaiUrl))

--- a/src/modules/llms/server/openai/models/daoxe.models.ts
+++ b/src/modules/llms/server/openai/models/daoxe.models.ts
@@ -1,0 +1,70 @@
+import { DModelInterfaceV1, LLM_IF_OAI_Chat, LLM_IF_OAI_Fn, LLM_IF_OAI_Vision } from '~/common/stores/llms/llms.types';
+
+import { serverCapitalizeFirstLetter } from '~/server/wire';
+
+import type { ModelDescriptionSchema } from '../../llm.server.types';
+import { fromManualMapping, llmsDefineManualMappings } from '../../models.mappings';
+
+import type { OpenAIWire_API_Models_List } from '~/modules/aix/server/dispatch/wiretypes/openai.wiretypes';
+
+
+export function daoxeHeuristic(hostname: string) {
+  // Match daoxe.com and subdomains (e.g. api.daoxe.com if used)
+  return hostname === 'daoxe.com' || hostname.endsWith('.daoxe.com');
+}
+
+
+const _daoxeKnownModels = llmsDefineManualMappings([
+  // No static model/price table: DaoXE catalogs are account-scoped and change over time.
+  // Runtime /v1/models is the source of truth.
+]);
+
+const _daoxeDenyListContains: string[] = [
+  // keep empty unless a non-chat id pattern appears
+] as const;
+
+
+function _prettyModelId(modelId: string): string {
+  return modelId
+    .replaceAll(/[_-]/g, ' ')
+    .split(' ')
+    .map(piece => {
+      if (piece.match(/^\d+(\.\d+)*$/)) return piece;
+      if (piece.toLowerCase() === 'ai') return 'AI';
+      if (piece.match(/^v\d/i)) return piece.toUpperCase();
+      return serverCapitalizeFirstLetter(piece);
+    })
+    .join(' ')
+    .trim();
+}
+
+
+/**
+ * Map DaoXE OpenAI-compatible /v1/models list to Big-AGI model descriptions.
+ * Prefer live account catalog fields; do not invent a public static price list.
+ */
+export function daoxeModelsToModelDescriptions(
+  models: OpenAIWire_API_Models_List.Model[],
+): ModelDescriptionSchema[] {
+  return models
+    .filter((model) => !_daoxeDenyListContains.some((denied) => model.id.toLowerCase().includes(denied)))
+    .map((model): ModelDescriptionSchema => {
+      const label = _prettyModelId(model.id);
+      const description = 'DaoXE multi-model multi-protocol gateway model (OpenAI-compatible Chat Completions).';
+
+      const interfaces: DModelInterfaceV1[] = [LLM_IF_OAI_Chat, LLM_IF_OAI_Fn];
+      // Soft heuristics only — account catalog may differ
+      if (/vision|gpt-4o|claude|gemini|llava/i.test(model.id))
+        interfaces.push(LLM_IF_OAI_Vision);
+
+      return fromManualMapping(_daoxeKnownModels, model.id, model.created, undefined, {
+        idPrefix: model.id,
+        label,
+        description,
+        contextWindow: null,
+        interfaces,
+        // No chatPrice: avoid hardcoding public rates; users see live DaoXE pricing in-account.
+        hidden: false,
+      });
+    });
+}

--- a/src/modules/llms/vendors/openai/OpenAIHostAutocomplete.tsx
+++ b/src/modules/llms/vendors/openai/OpenAIHostAutocomplete.tsx
@@ -13,6 +13,7 @@ import { CloudflareIcon } from '~/common/components/icons/vendors/CloudflareIcon
 import { HeliconeIcon } from '~/common/components/icons/vendors/HeliconeIcon';
 import { MiniMaxIcon } from '~/common/components/icons/vendors/MiniMaxIcon';
 import { NovitaAIIcon } from '~/common/components/icons/vendors/NovitaAIIcon';
+import { DaoXEIcon } from '~/common/components/icons/vendors/DaoXEIcon';
 
 
 /**
@@ -40,6 +41,7 @@ const OPENAI_COMPATIBLE_PROVIDERS: VerifiedProvider[] = [
   // Example Providers
   { id: 'arcee', label: 'Arcee AI', host: 'https://api.arcee.ai/api', hostMatch: 'arcee.ai', category: 'Example Providers', description: 'Open-weight MoE models', docsUrl: 'https://docs.arcee.ai/', icon: ArceeAIIcon },
   { id: 'chutes', label: 'Chutes AI', host: 'https://llm.chutes.ai', hostMatch: '.chutes.ai', category: 'Example Providers', description: 'Serverless open model inference', docsUrl: 'https://chutes.ai/docs', icon: ChutesAIIcon },
+  { id: 'daoxe', label: 'DaoXE', host: 'https://daoxe.com', hostMatch: 'daoxe.com', category: 'Example Providers', description: 'Multi-model multi-protocol AI API gateway', docsUrl: 'https://github.com/seven7763/DaoXE-AI', icon: DaoXEIcon },
   { id: 'empiriolabs', label: 'EmpirioLabs AI', host: 'https://api.empiriolabs.ai', hostMatch: 'empiriolabs.ai', category: 'Example Providers', description: 'Multi-model API platform', docsUrl: 'https://docs.empiriolabs.ai' },
   { id: 'fireworks', label: 'Fireworks AI', host: 'https://api.fireworks.ai/inference', hostMatch: 'fireworks.ai', category: 'Example Providers', description: 'Fast open model inference', docsUrl: 'https://docs.fireworks.ai/getting-started/quickstart', icon: FireworksAIIcon },
   { id: 'llmapi', label: 'LLM API', host: 'https://api.llmapi.ai', hostMatch: 'llmapi.ai', category: 'Example Providers', description: 'Multi-provider API gateway', docsUrl: 'https://llmapi.ai' },


### PR DESCRIPTION
## Summary
- Add **DaoXE** as a preferred Path-1 dynamic OpenAI-compatible backend (see `kb/modules/LLM-vendor-integration.md`).
- `daoxeHeuristic` matches `daoxe.com` hosts when listing models.
- Maps live `/v1/models` without a hard-coded public model/price table (account catalog is source of truth).
- Adds DaoXE to OpenAI-compatible host autocomplete + monochrome vendor icon.

DaoXE is a multi-model multi-protocol API gateway (`https://daoxe.com`, OpenAI Chat Completions at `/v1`). Also exposes OpenAI Responses and Anthropic Messages for other clients.

I am a DaoXE maintainer. Examples: https://github.com/seven7763/DaoXE-AI

## Test plan
- [ ] Models → add OpenAI-compatible host `https://daoxe.com` + DaoXE API key
- [ ] Model list loads via heuristic (not generic OpenAI filter only)
- [ ] Autocomplete shows DaoXE entry
- [ ] No static public price table committed