### PR TITLE
Bedrock: support Mantle models that only implement the OpenAI Responses API

### DIFF
--- a/src/common/logic/reconfigureBackendModels.ts
+++ b/src/common/logic/reconfigureBackendModels.ts
@@ -34,8 +34,6 @@ export async function reconfigureBackendModels(lastLlmReconfigHash: string, setL
 
   // begin configuration
   _isConfiguring = true;
-  // FIXME: future: move this to the end of the function, but also with strong retry count and error catching, so one's app wouldn't loop upon each boot
-  setLastReconfigHash(backendReconfigHash);
   const initiallyEmpty = !llmsStoreState().llms?.length;
 
   // reconfigure these
@@ -64,6 +62,7 @@ export async function reconfigureBackendModels(lastLlmReconfigHash: string, setL
 
   // track in order the services that were configured
   const configuredServiceIds: DModelsServiceId[] = [];
+  let configurationSuccesses = 0;
 
   // sequentially re-configure
   await servicesToReconfigure.reduce(async (promiseChain, service) => {
@@ -74,6 +73,7 @@ export async function reconfigureBackendModels(lastLlmReconfigHash: string, setL
 
         // auto-configure this service
         await llmsUpdateModelsForServiceOrThrow(service.id, true);
+        configurationSuccesses++;
       })
       .catch(error => {
         // catches errors and logs them, but does not stop the chain
@@ -84,6 +84,13 @@ export async function reconfigureBackendModels(lastLlmReconfigHash: string, setL
         return new Promise(resolve => setTimeout(resolve, 50));
       });
   }, Promise.resolve());
+
+  // Persist the reconfig hash only if configuration made progress: at least one service succeeded,
+  // or there was nothing to configure. On total failure (e.g. transient network error on first load)
+  // the hash is left unset so the next boot retries, instead of permanently skipping auto-configuration
+  // for this browser. Within this session the _isConfigurationDone guard still prevents re-runs.
+  if (!servicesToReconfigure.length || configurationSuccesses > 0)
+    setLastReconfigHash(backendReconfigHash);
 
   // Re-rank the LLMs based on the order of configured services
   llmsStoreActions().rerankLLMsByServices(configuredServiceIds);

--- a/src/common/stores/llms/llms.parameters.ts
+++ b/src/common/stores/llms/llms.parameters.ts
@@ -293,7 +293,7 @@ export const DModelParameterRegistry = {
     label: 'Bedrock API',
     type: 'enum',
     description: 'Bedrock invocation API for this model',
-    values: ['converse', 'invoke-anthropic', 'mantle'],
+    values: ['converse', 'invoke-anthropic', 'mantle', 'mantle-responses'],
     // undefined is not accepted when this parameter is used
   }),
 

--- a/src/modules/aix/server/api/aix.wiretypes.ts
+++ b/src/modules/aix/server/api/aix.wiretypes.ts
@@ -527,7 +527,7 @@ export namespace AixWire_API {
     vndAntWebSearchMaxUses: z.number().int().min(1).max(50).optional(),
 
     // Bedrock
-    vndBedrockAPI: z.enum(['converse', 'invoke-anthropic', 'mantle']).optional(),
+    vndBedrockAPI: z.enum(['converse', 'invoke-anthropic', 'mantle', 'mantle-responses']).optional(),
 
     // Gemini
     vndGeminiAPI: z.enum(['interactions-agent']).optional(), // opt-in per-model API dialect; unset = generateContent

--- a/src/modules/aix/server/dispatch/chatGenerate/chatGenerate.dispatch.ts
+++ b/src/modules/aix/server/dispatch/chatGenerate/chatGenerate.dispatch.ts
@@ -161,6 +161,21 @@ export async function createChatGenerateDispatch(access: AixAPI_Access, model: A
             chatGenerateParse: streaming ? createOpenAIChatCompletionsChunkParser() : createOpenAIChatCompletionsParserNS(),
           };
 
+        // [Bedrock Mantle Responses] OpenAI Responses-compatible API - required by OpenAI frontier models (GPT-5.4+), which reject Chat Completions
+        // NOTE: these models live on the '/openai/v1/responses' path, distinct from the '/v1/responses' path used by other models (per AWS model cards)
+        case 'mantle-responses':
+          const mantleResponsesUrl = bedrockURLMantle(bedrockResolveRegion(access), '/openai/v1/responses');
+          const mantleResponsesBody = aixToOpenAIResponses('openai', model, chatGenerate, streaming, false /* no reattach support for the bedrock dialect, don't store upstream */);
+          return {
+            request: {
+              ...await bedrockAccessAsync(access, 'POST', mantleResponsesUrl, mantleResponsesBody),
+              method: 'POST',
+              body: mantleResponsesBody,
+            },
+            demuxerFormat: streaming ? 'fast-sse' : null,
+            chatGenerateParse: streaming ? createOpenAIResponsesEventParser('openai') : createOpenAIResponseParserNS('openai'),
+          };
+
         default:
           const _exhaustiveCheck: never = model.vndBedrockAPI;
         // fallthrough, then throw

--- a/src/modules/backend/backend.router.ts
+++ b/src/modules/backend/backend.router.ts
@@ -23,7 +23,7 @@ function sdbmHash(str: string): string {
 function generateLlmEnvConfigHash(env: Record<string, unknown>): string {
   const envAPIKeys = Object.keys(env)     // get all env keys
     .filter(key => !!env[key])            // minus the empty
-    .filter(key => key.includes('_API_')) // minus the non-API keys
+    .filter(key => key.includes('_API_') || key.startsWith('BEDROCK_')) // LLM service keys: '_API_' misses the BEDROCK_* vars (ACCESS_KEY_ID/SECRET_ACCESS_KEY/BEARER_TOKEN), which would never re-trigger client autoconf
     .map(key => `${key}=${env[key]}`)     // create key-value pairs
     .sort();                              // ignore order
   const hashInputs = [

--- a/src/modules/llms/server/anthropic/anthropic.models.ts
+++ b/src/modules/llms/server/anthropic/anthropic.models.ts
@@ -888,6 +888,7 @@ function _llmBedrockToAnthropicModelId(bedrockBaseId: string): string | undefine
 const _BEDROCK_ANT_IF_ALLOWLIST: ReadonlySet<string> = new Set([
   LLM_IF_OAI_Chat, LLM_IF_OAI_Vision, LLM_IF_OAI_Fn, LLM_IF_OAI_Reasoning,
   LLM_IF_ANT_PromptCaching,
+  LLM_IF_HOTFIX_NoTemperature, // keep: Bedrock rejects temperature for the same models as the direct API ('"temperature" is deprecated for this model.')
 ] as const);
 
 // NOTE: llmVndAntInfSpeed not available on Bedrock, llmVndAntWebFetch/llmVndAntSkills not available

--- a/src/modules/llms/server/bedrock/bedrock.models.ts
+++ b/src/modules/llms/server/bedrock/bedrock.models.ts
@@ -15,7 +15,7 @@ import * as z from 'zod/v4';
 import type { ModelDescriptionSchema } from '../llm.server.types';
 
 import { llmsAntInjectVariants, llmBedrockFindAnthropicModel, llmBedrockStripAnthropicMDS } from '../anthropic/anthropic.models';
-import { LLM_IF_ANT_PromptCaching, LLM_IF_OAI_Chat, LLM_IF_OAI_Fn, LLM_IF_OAI_Reasoning, LLM_IF_OAI_Vision, LLM_IF_Outputs_Audio, LLM_IF_Outputs_Image } from '~/common/stores/llms/llms.types';
+import { LLM_IF_ANT_PromptCaching, LLM_IF_HOTFIX_NoTemperature, LLM_IF_OAI_Chat, LLM_IF_OAI_Fn, LLM_IF_OAI_Reasoning, LLM_IF_OAI_Vision, LLM_IF_Outputs_Audio, LLM_IF_Outputs_Image } from '~/common/stores/llms/llms.types';
 import { DModelParameterSpecAny } from '~/common/stores/llms/llms.parameters';
 
 
@@ -25,9 +25,16 @@ const SKIP_FM_ID_CONTAINS = ['rerank'];
 const SKIP_IP_ID_STARTSWITH = ['stability.'];
 
 // Known Mantle-only models (no matching foundation model) - override heuristics with accurate metadata
-const KNOWN_MANTLE_ONLY: Record<string, { label: string; ctx: number; out: number; vision?: true; reasoning?: true }> = {
+// `api: 'responses'`: model only implements the OpenAI Responses API (on the '/openai/v1/responses' path) and rejects
+// Chat Completions with a 400 - see https://docs.aws.amazon.com/bedrock/latest/userguide/models-api-compatibility.html
+const KNOWN_MANTLE_ONLY: Record<string, { label: string; ctx: number; out: number; vision?: true; reasoning?: true; api?: 'responses' }> = {
   'deepseek.v3.1': { label: 'DeepSeek V3.1', ctx: 131072, out: 16384 },
   'moonshotai.kimi-k2-thinking': { label: 'Kimi K2 Thinking', ctx: 131072, out: 16384 },
+  'openai.gpt-5.4': { label: 'GPT-5.4', ctx: 272000, out: 128000, vision: true, reasoning: true, api: 'responses' },
+  'openai.gpt-5.5': { label: 'GPT-5.5', ctx: 272000, out: 128000, vision: true, reasoning: true, api: 'responses' },
+  'openai.gpt-5.6-luna': { label: 'GPT-5.6 Luna', ctx: 272000, out: 128000, vision: true, reasoning: true, api: 'responses' },
+  'openai.gpt-5.6-sol': { label: 'GPT-5.6 Sol', ctx: 272000, out: 128000, vision: true, reasoning: true, api: 'responses' },
+  'openai.gpt-5.6-terra': { label: 'GPT-5.6 Terra', ctx: 272000, out: 128000, vision: true, reasoning: true, api: 'responses' },
   'openai.gpt-oss-20b': { label: 'GPT-OSS 20B', ctx: 131072, out: 16384 },
   'openai.gpt-oss-120b': { label: 'GPT-OSS 120B', ctx: 131072, out: 16384 },
   'qwen.qwen3-32b': { label: 'Qwen3 32B', ctx: 131072, out: 16384 },
@@ -266,6 +273,7 @@ export function bedrockModelsToDescriptions(
   const bedrockAPIAnthropic = { paramId: 'llmVndBedrockAPI', initialValue: 'invoke-anthropic' } as const satisfies DModelParameterSpecAny;
   const bedrockAPIConverse = { paramId: 'llmVndBedrockAPI', initialValue: 'converse' } as const satisfies DModelParameterSpecAny;
   const bedrockAPIMantle = { paramId: 'llmVndBedrockAPI', initialValue: 'mantle' } as const satisfies DModelParameterSpecAny;
+  const bedrockAPIMantleResponses = { paramId: 'llmVndBedrockAPI', initialValue: 'mantle-responses' } as const satisfies DModelParameterSpecAny;
   for (const [modelId, modelMeta] of modelMap) {
     if (_seemsAnthropicBedrockModel(modelId)) {
 
@@ -327,20 +335,23 @@ export function bedrockModelsToDescriptions(
 
   // -> Add remaining Mantle-only models (not matched to any FM/IP)
   for (const mantleId of remainingMantleModelIds) {
-    const known = KNOWN_MANTLE_ONLY[mantleId];
+    const known = _findKnownMantleModel(mantleId);
+    const isResponsesOnly = known?.api === 'responses';
     const provider = _extractMantleProvider(mantleId);
     const interfaces = [LLM_IF_OAI_Chat];
     if (known?.vision) interfaces.push(LLM_IF_OAI_Vision);
     if (known?.reasoning) interfaces.push(LLM_IF_OAI_Reasoning);
+    if (isResponsesOnly) interfaces.push(LLM_IF_OAI_Fn); // Responses API supports function tools
+    if (isResponsesOnly) interfaces.push(LLM_IF_HOTFIX_NoTemperature); // GPT-5.x frontier reasoning models reject temperature ('Unsupported parameter') - same as on the OpenAI vendor
     descriptions.push({
       id: mantleId,
       label: `${symbolMantle}${known?.label ?? labelForMantle(mantleId, provider)}${known ? '' : ' [?]'}`,
-      description: `${provider} model via OpenAI-Compatible API on AWS Bedrock Mantle`,
+      description: `${provider} model via OpenAI-Compatible ${isResponsesOnly ? 'Responses ' : ''}API on AWS Bedrock Mantle`,
       contextWindow: known?.ctx ?? 131072,
       maxCompletionTokens: known?.out ?? 16384,
       interfaces,
-      parameterSpecs: [bedrockAPIMantle],
-      hidden: true, // we know it can run, but we don't have models details
+      parameterSpecs: [isResponsesOnly ? bedrockAPIMantleResponses : bedrockAPIMantle],
+      hidden: !isResponsesOnly, // show models with a curated API assignment; hide the rest (they run, but we don't have model details)
     });
   }
 
@@ -349,6 +360,11 @@ export function bedrockModelsToDescriptions(
 
 
 // --- Helpers ---
+
+/** Find a KNOWN_MANTLE_ONLY entry: exact ID first, then with a trailing '-YYYY-MM-DD' snapshot suffix stripped (e.g. 'openai.gpt-5.4-2026-03-05' -> 'openai.gpt-5.4') */
+function _findKnownMantleModel(mantleId: string): typeof KNOWN_MANTLE_ONLY[string] | undefined {
+  return KNOWN_MANTLE_ONLY[mantleId] ?? KNOWN_MANTLE_ONLY[mantleId.replace(/-\d{4}-\d{2}-\d{2}$/, '')];
+}
 
 // Extract provider name from Mantle model ID (e.g., 'mistral.model-name' -> 'Mistral')
 function _extractMantleProvider(modelId: string): string {


### PR DESCRIPTION
## What

Adds a `mantle-responses` value to the `llmVndBedrockAPI` model parameter, dispatching Bedrock Mantle models through the OpenAI **Responses** API instead of Chat Completions, plus a small fix so `LLM_IF_HOTFIX_NoTemperature` survives the Bedrock model listing for Anthropic models.

## Why

Some Bedrock Mantle models only implement the OpenAI Responses API. Today that's the OpenAI frontier family (GPT-5.4, GPT-5.5, GPT-5.6 Sol / Terra / Luna): they appear in the model list (via Mantle `GET /v1/models`) but every invoke fails with:

> **400**: The model 'openai.gpt-5.6-terra' does not support the '/v1/chat/completions' API

because the `mantle` dispatch hardcodes `POST /v1/chat/completions`.

Note the path detail: per the AWS model cards, these models are served on the **`/openai/v1/responses`** path — different from the `/v1/responses` path used by other models on the responses endpoint (see the "API compatibility by models" page and e.g. the GPT-5.5 model card in the AWS Bedrock user guide).

## How

- `llms.parameters.ts` / `aix.wiretypes.ts`: extend the `llmVndBedrockAPI` enum with `mantle-responses`.
- `chatGenerate.dispatch.ts`: new `case 'mantle-responses'` — `bedrockURLMantle(region, '/openai/v1/responses')`, body from the existing `aixToOpenAIResponses` adapter, parsed with `createOpenAIResponsesEventParser('openai')` / `createOpenAIResponseParserNS('openai')`, signed with the existing `bedrockAccessAsync` (no auth changes).
- `bedrock.models.ts`: the `KNOWN_MANTLE_ONLY` map gains an `api: 'responses'` marker (matched exactly or with a trailing `-YYYY-MM-DD` snapshot suffix stripped, e.g. `openai.gpt-5.4-2026-03-05`), with metadata per the AWS docs (272K context, vision, reasoning). These models also reject `temperature` ("Unsupported parameter: 'temperature' is not supported with this model."), so they carry `LLM_IF_HOTFIX_NoTemperature` like their OpenAI-vendor counterparts.
- `anthropic.models.ts` (second commit): `_BEDROCK_ANT_IF_ALLOWLIST` was stripping `LLM_IF_HOTFIX_NoTemperature` from Claude models listed via Bedrock, so clients kept sending `temperature` and Bedrock rejected it with `400: "\`temperature\` is deprecated for this model."` (Claude Sonnet 5 base / Fable 5). The direct Anthropic vendor was unaffected. The flag is now allowlisted.

## Tested

All verified live against `bedrock-mantle.us-east-1.api.aws` (SigV4):

- `openai.gpt-5.6-terra` via `mantle-responses`: streaming and non-streaming ✅
- No regressions on the other three Bedrock paths: `zai.glm-4.7-flash` (mantle / Chat Completions), Nova Pro (converse), Claude Sonnet 5 + Claude Fable 5 (invoke-anthropic) ✅
- Model listing: all Responses-only IDs (including dated snapshots) get the `mantle-responses` spec; gpt-oss / Grok models that support both APIs stay on `mantle` ✅
- `temperature` regression: Bedrock-listed Sonnet 5 / Fable 5 and the GPT-5.x Mantle models now carry `hotfix-no-temperature`, so clients omit temperature and the 400s are gone ✅
- `tsc --noEmit` clean, `next build` passes

## Also included: server-configured vendors not auto-appearing for new users

Two related fixes for backend-configured services (found while deploying a Bedrock-only instance):

- **`reconfigureBackendModels.ts`**: the reconfig hash was persisted *before* the configuration loop, so a transient failure in `llmsUpdateModelsForServiceOrThrow` (swallowed by the catch) permanently skipped auto-configuration for that browser. The hash is now persisted after the loop, and only when at least one service configured successfully (or there was nothing to configure) — on total failure the next boot retries. Resolves the existing `FIXME` on that line; the in-session double-run guard is unchanged.
- **`backend.router.ts`**: `generateLlmEnvConfigHash` filtered env keys with `key.includes('_API_')`, which excludes all `BEDROCK_*` vars — Bedrock-only deployments never (re-)triggered client autoconfiguration. The filter now also matches `key.startsWith('BEDROCK_')`. The env values only feed a one-way hash, same as the existing `*_API_KEY` values.
