### PR TITLE
Bedrock: opt-in ambient IAM via the container credentials endpoint

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -34,6 +34,7 @@ BEDROCK_ACCESS_KEY_ID=
 BEDROCK_SECRET_ACCESS_KEY=
 BEDROCK_SESSION_TOKEN=
 BEDROCK_REGION=
+BEDROCK_USE_CONTAINER_CREDENTIALS=
 DEEPSEEK_API_KEY=
 GEMINI_API_KEY=
 GROQ_API_KEY=
@@ -109,6 +110,7 @@ requiring the user to enter an API key
 | `BEDROCK_SECRET_ACCESS_KEY` | AWS IAM Secret Access Key for Bedrock                                                                          | Optional, but if set `BEDROCK_ACCESS_KEY_ID` must also be set      |
 | `BEDROCK_SESSION_TOKEN`     | AWS Session Token for temporary/STS credentials                                                                | Optional                                                          |
 | `BEDROCK_REGION`            | AWS region for Bedrock (e.g., `us-east-1`, `us-west-2`, `eu-west-1`)                                          | Optional, defaults to `us-east-1`                                 |
+| `BEDROCK_USE_CONTAINER_CREDENTIALS` | Set to `true` to use ambient IAM credentials from the ECS/Fargate container credentials endpoint (task role) when no explicit Bedrock credentials are configured. Lowest priority in the credentials chain | Optional                                                          |
 | `DEEPSEEK_API_KEY`          | The API key for Deepseek AI                                                                                    | Optional                                                          |
 | `GEMINI_API_KEY`            | The API key for Google AI's Gemini                                                                             | Optional                                                          |
 | `GROQ_API_KEY`              | The API key for Groq Cloud                                                                                     | Optional                                                          |

--- a/src/modules/backend/backend.router.ts
+++ b/src/modules/backend/backend.router.ts
@@ -6,6 +6,8 @@ import { createTRPCRouter, publicProcedure } from '~/server/trpc/trpc.server';
 import { env } from '~/server/env.server';
 import { fetchJsonOrTRPCThrow } from '~/server/trpc/trpc.router.fetchers';
 
+import { bedrockHasContainerCredentialsEndpoint } from '~/modules/llms/server/bedrock/bedrock.containerCredentials';
+
 // critical to make sure we `import type` here
 import type { BackendCapabilities } from './store-backend-capabilities';
 
@@ -51,7 +53,7 @@ export const backendRouter = createTRPCRouter({
         hasLlmAlibaba: !!env.ALIBABA_API_KEY || !!env.ALIBABA_API_HOST,
         hasLlmAnthropic: !!env.ANTHROPIC_API_KEY,
         hasLlmAzureOpenAI: !!env.AZURE_OPENAI_API_KEY && !!env.AZURE_OPENAI_API_ENDPOINT,
-        hasLlmBedrock: !!env.BEDROCK_BEARER_TOKEN || (!!env.BEDROCK_ACCESS_KEY_ID && !!env.BEDROCK_SECRET_ACCESS_KEY),
+        hasLlmBedrock: !!env.BEDROCK_BEARER_TOKEN || (!!env.BEDROCK_ACCESS_KEY_ID && !!env.BEDROCK_SECRET_ACCESS_KEY) || (!!env.BEDROCK_USE_CONTAINER_CREDENTIALS && bedrockHasContainerCredentialsEndpoint()),
         hasLlmDeepseek: !!env.DEEPSEEK_API_KEY,
         hasLlmGemini: !!env.GEMINI_API_KEY,
         hasLlmGroq: !!env.GROQ_API_KEY,

--- a/src/modules/llms/server/bedrock/bedrock.access.ts
+++ b/src/modules/llms/server/bedrock/bedrock.access.ts
@@ -11,8 +11,9 @@
  *   UNSUPPORTED: Short-term keys (`bedrock-api-key-...`) only support runtime (not model listing).
  * - **SigV4**: Traditional IAM credentials signing via aws4fetch
  *
- * Priority: client bearer > client IAM > server bearer > server IAM.
- * SigV4 uses explicit AWS credentials only (no credential chain) for Edge Runtime compatibility.
+ * Priority: client bearer > client IAM > server bearer > server IAM > container credentials (opt-in).
+ * SigV4 uses explicit AWS credentials only (no SDK credential chain) for Edge Runtime compatibility;
+ * the optional container-credentials provider is likewise pure-fetch (see bedrock.containerCredentials.ts).
  */
 
 import * as z from 'zod/v4';
@@ -21,6 +22,8 @@ import { TRPCError } from '@trpc/server';
 import { AwsClient } from 'aws4fetch';
 
 import { env } from '~/server/env.server';
+
+import { bedrockContainerCredentialsOrNull } from './bedrock.containerCredentials';
 
 
 // configuration
@@ -46,8 +49,13 @@ export const bedrockAccessSchema = z.object({
 type BedrockAuthBearer = { type: 'bearer'; bearerToken: string; region: string };
 type BedrockAuthSigV4 = { type: 'sigv4'; accessKeyId: string; secretAccessKey: string; sessionToken: string | undefined; region: string };
 
-/** Resolve Bedrock authentication. */
-function _bedrockResolveAuth(access: BedrockAccessSchema): BedrockAuthBearer | BedrockAuthSigV4 {
+/** True when the client provided its own credentials (bearer or IAM pair). */
+function _hasClientCredentials(access: BedrockAccessSchema): boolean {
+  return !!access.bedrockBearerToken || (!!access.bedrockAccessKeyId && !!access.bedrockSecretAccessKey);
+}
+
+/** Resolve Bedrock authentication. Async because ambient container credentials may need a fetch. */
+async function _bedrockResolveAuthAsync(access: BedrockAccessSchema): Promise<BedrockAuthBearer | BedrockAuthSigV4> {
 
   // 1. Client bearer token (highest priority)
   let region = access.bedrockRegion || DEFAULT_BEDROCK_REGION; // client-provided region
@@ -67,15 +75,28 @@ function _bedrockResolveAuth(access: BedrockAccessSchema): BedrockAuthBearer | B
   if (env.BEDROCK_ACCESS_KEY_ID && env.BEDROCK_SECRET_ACCESS_KEY)
     return { type: 'sigv4', accessKeyId: env.BEDROCK_ACCESS_KEY_ID, secretAccessKey: env.BEDROCK_SECRET_ACCESS_KEY, sessionToken: env.BEDROCK_SESSION_TOKEN || undefined, region };
 
+  // 5. [opt-in] Ambient container credentials (ECS/Fargate task role) - short-lived, cached with refresh
+  if (env.BEDROCK_USE_CONTAINER_CREDENTIALS) {
+    const ambient = await bedrockContainerCredentialsOrNull();
+    if (ambient)
+      return { type: 'sigv4', accessKeyId: ambient.accessKeyId, secretAccessKey: ambient.secretAccessKey, sessionToken: ambient.sessionToken, region };
+  }
+
   throw new TRPCError({
     code: 'BAD_REQUEST',
     message: 'Missing AWS credentials. Add your Bedrock API Key or IAM Access Key on the UI (Models Setup) or server side (your deployment).',
   });
 }
 
-/** Resolve the Bedrock region from access config. */
+/**
+ * Resolve the Bedrock region from access config - deliberately sync and credential-free:
+ * client-provided credentials use the client region, server-side credentials (bearer, IAM
+ * env vars, or ambient container credentials) use the server region.
+ */
 export function bedrockResolveRegion(access: BedrockAccessSchema): string {
-  return _bedrockResolveAuth(access).region;
+  return _hasClientCredentials(access)
+    ? access.bedrockRegion || DEFAULT_BEDROCK_REGION
+    : env.BEDROCK_REGION || DEFAULT_BEDROCK_REGION;
 }
 
 
@@ -111,7 +132,7 @@ export async function bedrockAccessAsync(
   body?: object,
 ): Promise<{ headers: HeadersInit; url: string }> {
 
-  const auth = _bedrockResolveAuth(access);
+  const auth = await _bedrockResolveAuthAsync(access);
 
   // -- Bearer token: simple Authorization header --
   if (auth.type === 'bearer')

--- a/src/modules/llms/server/bedrock/bedrock.containerCredentials.ts
+++ b/src/modules/llms/server/bedrock/bedrock.containerCredentials.ts
@@ -1,0 +1,113 @@
+/**
+ * Ambient AWS credentials from the container credentials endpoint (ECS/Fargate task roles).
+ *
+ * Zero-dependency and Edge Runtime compatible: only `fetch` and env vars are used (no AWS
+ * SDK, no filesystem, no Node APIs). Opt-in via BEDROCK_USE_CONTAINER_CREDENTIALS=true.
+ *
+ * Supported (the "container" credential provider - https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html):
+ * - ECS/Fargate task roles: AWS_CONTAINER_CREDENTIALS_RELATIVE_URI, served by the ECS agent
+ *   at the link-local address http://169.254.170.2
+ * - AWS_CONTAINER_CREDENTIALS_FULL_URI, with the optional static AWS_CONTAINER_AUTHORIZATION_TOKEN
+ *
+ * NOT supported (would need more machinery than a fetch):
+ * - EC2 IMDSv2 (different token+discovery protocol)
+ * - EKS IRSA (requires an STS AssumeRoleWithWebIdentity call)
+ * - EKS Pod Identity (AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE rotates on disk; the Edge Runtime has no fs)
+ *
+ * Lifecycle: task-role credentials rotate (~hours), so we cache at module level, refresh with
+ * a safety margin before expiration, single-flight concurrent refreshes, and keep serving the
+ * cached credentials on refresh failures for as long as they are still valid.
+ */
+
+// configuration
+const _ECS_CREDENTIALS_HOST = 'http://169.254.170.2'; // ECS agent, link-local
+const _EXPIRY_MARGIN_MS = 5 * 60 * 1000; // refresh 5 minutes before expiration
+const _FETCH_TIMEOUT_MS = 5 * 1000; // generous - the endpoint is link-local (measured <100ms)
+
+
+export interface BedrockContainerCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string | undefined; // always present on ECS task roles, but not required for signing
+  expiresAt: number; // epoch ms
+}
+
+// module-level cache - persists across invocations within the server (or Edge sandbox) instance
+let _cache: BedrockContainerCredentials | null = null;
+let _inflightRefresh: Promise<BedrockContainerCredentials> | null = null;
+let _loggedFirstUse = false;
+
+
+/** True when the runtime exposes a container credentials endpoint (e.g. ECS/Fargate with a task role). */
+export function bedrockHasContainerCredentialsEndpoint(): boolean {
+  return !!process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI || !!process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI;
+}
+
+/**
+ * Returns valid (cached or freshly fetched) container credentials, or null when unavailable,
+ * letting the caller fall through to its standard missing-credentials error.
+ */
+export async function bedrockContainerCredentialsOrNull(): Promise<BedrockContainerCredentials | null> {
+
+  // fresh cache hit
+  if (_cache && Date.now() < _cache.expiresAt - _EXPIRY_MARGIN_MS)
+    return _cache;
+
+  // single-flight: concurrent requests await the same refresh
+  if (!_inflightRefresh)
+    _inflightRefresh = _fetchContainerCredentials().finally(() => _inflightRefresh = null);
+
+  try {
+    _cache = await _inflightRefresh;
+    return _cache;
+  } catch (error: any) {
+    // stale-tolerant: on refresh failure keep serving cached credentials until they actually expire
+    if (_cache && Date.now() < _cache.expiresAt)
+      return _cache;
+    console.warn('[Bedrock] container credentials unavailable:', error?.message || error);
+    return null;
+  }
+}
+
+async function _fetchContainerCredentials(): Promise<BedrockContainerCredentials> {
+
+  // resolve the endpoint
+  const relativeUri = process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI;
+  const url = relativeUri ? _ECS_CREDENTIALS_HOST + relativeUri : process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI;
+  if (!url)
+    throw new Error('no container credentials endpoint (AWS_CONTAINER_CREDENTIALS_RELATIVE_URI/_FULL_URI unset)');
+
+  // optional static authorization token (the rotating _TOKEN_FILE variant is not supported - see header)
+  const authToken = process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN;
+
+  const response = await fetch(url, {
+    headers: {
+      'Accept': 'application/json',
+      ...(authToken ? { 'Authorization': authToken } : {}),
+    },
+    signal: AbortSignal.timeout(_FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok)
+    throw new Error(`credentials endpoint returned HTTP ${response.status}`);
+
+  const wireCreds = await response.json() as { RoleArn?: string; AccessKeyId?: string; SecretAccessKey?: string; Token?: string; Expiration?: string };
+  if (!wireCreds?.AccessKeyId || !wireCreds.SecretAccessKey || !wireCreds.Expiration)
+    throw new Error('credentials endpoint returned an unexpected payload');
+
+  const expiresAt = Date.parse(wireCreds.Expiration);
+  if (isNaN(expiresAt))
+    throw new Error(`credentials endpoint returned an invalid Expiration: ${wireCreds.Expiration}`);
+
+  // log once, as operational evidence of the ambient auth mode
+  if (!_loggedFirstUse) {
+    _loggedFirstUse = true;
+    console.log(`[Bedrock] using container credentials${wireCreds.RoleArn ? ` (role: ${wireCreds.RoleArn})` : ''}, expiring ${wireCreds.Expiration}`);
+  }
+
+  return {
+    accessKeyId: wireCreds.AccessKeyId,
+    secretAccessKey: wireCreds.SecretAccessKey,
+    sessionToken: wireCreds.Token || undefined,
+    expiresAt,
+  };
+}

--- a/src/server/env.server.ts
+++ b/src/server/env.server.ts
@@ -59,6 +59,7 @@ export const env = createEnv({
     BEDROCK_SECRET_ACCESS_KEY: z.string().optional(),
     BEDROCK_SESSION_TOKEN: z.string().optional(), // required with the other 2 on corporate accounts sometimes
     BEDROCK_REGION: z.string().optional(),
+    BEDROCK_USE_CONTAINER_CREDENTIALS: z.enum(['true']).optional(), // opt-in: ambient IAM via the ECS/Fargate container credentials endpoint (task role), lowest priority
 
     // LLM: Cerebras
     CEREBRAS_API_KEY: z.string().optional(),


### PR DESCRIPTION
## What

Opt-in ambient AWS IAM credentials for Bedrock via the **container credentials endpoint** (ECS/Fargate task roles): set `BEDROCK_USE_CONTAINER_CREDENTIALS=true` and big-AGI authenticates with the task's IAM role — no static `BEDROCK_ACCESS_KEY_ID` / `BEDROCK_SECRET_ACCESS_KEY` needed.

## Why

Enterprises with IAM-role-only security mandates cannot use long-lived static credentials — a hard requirement in many orgs (see e.g. [BerriAI/litellm#29665](https://github.com/BerriAI/litellm/issues/29665), which documents deployments where "a long-lived Bedrock API key ... is a non-starter under the security posture: no long-lived static secrets, IAM-role-only access"; litellm has a trail of similar asks). For big-AGI on ECS/Fargate this currently forces an IAM user + secret distribution + rotation machinery that the platform already solves natively with task roles.

## How — Edge Runtime compatible, zero dependencies

The existing constraint ("SigV4 uses explicit credentials only, no SDK credential chain, for Edge Runtime compatibility") is honored: **no AWS SDK is introduced**. On ECS the agent injects `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, and a plain `fetch` of `http://169.254.170.2<uri>` returns `{ AccessKeyId, SecretAccessKey, Token, Expiration }` as JSON. The existing `aws4fetch` signer already accepts `sessionToken`, so short-lived role credentials need **no signing changes**.

Empirical Edge-sandbox verification (self-hosted `next start`, which runs `runtime = 'edge'` routes in the edge-runtime sandbox): `globalThis.EdgeRuntime === 'edge-runtime'`, no Node `process.version`, yet `process.env` is readable and `fetch` reaches the credentials endpoint (measured <100 ms; it's link-local). On Vercel/Cloudflare the env var never exists, so the code path stays dormant.

- **`bedrock.containerCredentials.ts`** (new, ~110 lines): endpoint detection (`AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` / `_FULL_URI`, optional static `AWS_CONTAINER_AUTHORIZATION_TOKEN`), module-level cache, refresh 5 minutes before `Expiration`, single-flight concurrent refreshes, stale-tolerant on refresh failure while credentials remain valid, one-time log of the assumed role. Out of scope by design (documented in the header): EC2 IMDSv2, EKS IRSA, EKS Pod Identity's rotating token *file* (needs `fs`, unavailable on Edge).
- **`bedrock.access.ts`**: ambient credentials slot in at the **lowest priority** — client bearer > client IAM > server bearer > server IAM env > container credentials (opt-in). Explicit configuration always wins; existing deployments see zero behavior change unless they set the flag. `_bedrockResolveAuth` becomes async; `bedrockResolveRegion` is split out to stay sync and credential-free (same region semantics as before).
- **`backend.router.ts`**: `hasLlmBedrock` also lights up when the flag is set and the endpoint is present, so client auto-configuration works for keyless deployments.
- **`env.server.ts`** + **`docs/environment-variables.md`**: the new variable.

## Tested

- **Live on ECS Fargate (us-east-1), task role only** (no credential env vars in the task definition): model listing (140 models) plus chats across all Bedrock API paths — Converse (Nova Pro), Invoke-Anthropic (Claude Sonnet 5, Fable 5), and Mantle. Container logs show the one-time `[Bedrock] using container credentials (role: arn:aws:iam::…:role/…)` line.
- **Credential lifecycle**: a single credentials fetch served an entire session of concurrent listing + chat requests (cache + single-flight verified).
- **Priority**: with explicit env credentials present alongside the flag, the ambient endpoint is never contacted.
- **Failure path**: with the flag set but no endpoint (or fetch failure) and no other credentials, the standard "Missing AWS credentials" error is returned and a `console.warn` explains the ambient failure; a still-valid cached credential keeps serving through transient refresh failures.
- `tsc --noEmit` clean, `next build` passes.

## Notes

- Pairs well with (but does not depend on) the Bedrock Responses-API PR from the same deployment work; both are independently mergeable from `main`.
- Infra simplification for deployers: an ECS task role statement replaces the IAM user, secret distribution, and rotation machinery entirely; container env shrinks to `BEDROCK_REGION` + `BEDROCK_USE_CONTAINER_CREDENTIALS=true`.
