### PR TITLE
Bedrock: server-side model allowlist (BEDROCK_MODEL_ALLOWLIST)

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -34,6 +34,7 @@ BEDROCK_ACCESS_KEY_ID=
 BEDROCK_SECRET_ACCESS_KEY=
 BEDROCK_SESSION_TOKEN=
 BEDROCK_REGION=
+BEDROCK_MODEL_ALLOWLIST=
 DEEPSEEK_API_KEY=
 GEMINI_API_KEY=
 GROQ_API_KEY=
@@ -109,6 +110,7 @@ requiring the user to enter an API key
 | `BEDROCK_SECRET_ACCESS_KEY` | AWS IAM Secret Access Key for Bedrock                                                                          | Optional, but if set `BEDROCK_ACCESS_KEY_ID` must also be set      |
 | `BEDROCK_SESSION_TOKEN`     | AWS Session Token for temporary/STS credentials                                                                | Optional                                                          |
 | `BEDROCK_REGION`            | AWS region for Bedrock (e.g., `us-east-1`, `us-west-2`, `eu-west-1`)                                          | Optional, defaults to `us-east-1`                                 |
+| `BEDROCK_MODEL_ALLOWLIST`   | Comma-separated model IDs to expose (e.g. `anthropic.claude-sonnet-5,us.amazon.nova-pro-v1:0`). A base ID also admits its region-prefixed (`us.`/`eu.`/`global.`/…) inference profiles and Mantle variant. Enforced at model listing and chat generation | Optional, unset = all models                                       |
 | `DEEPSEEK_API_KEY`          | The API key for Deepseek AI                                                                                    | Optional                                                          |
 | `GEMINI_API_KEY`            | The API key for Google AI's Gemini                                                                             | Optional                                                          |
 | `GROQ_API_KEY`              | The API key for Groq Cloud                                                                                     | Optional                                                          |

--- a/src/modules/aix/server/dispatch/chatGenerate/chatGenerate.dispatch.ts
+++ b/src/modules/aix/server/dispatch/chatGenerate/chatGenerate.dispatch.ts
@@ -1,6 +1,6 @@
 import { ANTHROPIC_API_PATHS, anthropicAccess, anthropicBetaFeatures } from '~/modules/llms/server/anthropic/anthropic.access';
 import { OPENAI_API_PATHS, openAIAccess } from '~/modules/llms/server/openai/openai.access';
-import { bedrockAccessAsync, bedrockResolveRegion, bedrockURLMantle, bedrockURLRuntime } from '~/modules/llms/server/bedrock/bedrock.access';
+import { bedrockAccessAsync, bedrockModelAllowed, bedrockResolveRegion, bedrockURLMantle, bedrockURLRuntime } from '~/modules/llms/server/bedrock/bedrock.access';
 import { geminiAccess } from '~/modules/llms/server/gemini/gemini.access';
 import { ollamaAccess } from '~/modules/llms/server/ollama/ollama.access';
 
@@ -102,6 +102,11 @@ export async function createChatGenerateDispatch(access: AixAPI_Access, model: A
     }
 
     case 'bedrock': {
+
+      // server-side model allowlist (BEDROCK_MODEL_ALLOWLIST) - defense in depth over the listing filter
+      if (!bedrockModelAllowed(model.id))
+        throw new Error(`Model '${model.id}' is not enabled on this server. Ask your administrator to add it to BEDROCK_MODEL_ALLOWLIST.`);
+
       switch (model.vndBedrockAPI) {
 
         // [Bedrock Converse] Bedrock-native API, preferred for Amazon models and useful in others too

--- a/src/modules/llms/server/bedrock/bedrock.access.ts
+++ b/src/modules/llms/server/bedrock/bedrock.access.ts
@@ -79,6 +79,30 @@ export function bedrockResolveRegion(access: BedrockAccessSchema): string {
 }
 
 
+// --- Model Allowlist (optional, server-enforced) ---
+
+// region prefixes of inference profiles - keep in sync with _REGION_PREFIX_RE in bedrock.models.ts
+const _ALLOWLIST_REGION_PREFIX_RE = /^(us|eu|global|jp|apac)\./;
+
+/**
+ * Optional server-side model allowlist: BEDROCK_MODEL_ALLOWLIST (comma-separated model IDs).
+ * A model passes if its full ID or its region-prefix-stripped base ID is listed, so a single
+ * base entry (e.g. 'anthropic.claude-sonnet-5') covers the foundation model, its 'us.'/'eu.'/
+ * 'global.' inference profiles, and the Mantle variant; a prefixed entry (e.g.
+ * 'us.amazon.nova-pro-v1:0') admits just that profile. Unset/empty = all models allowed.
+ *
+ * This is enforced at both model listing and chat generation. It is effective (not cosmetic):
+ * the Bedrock vendor has no client-side-fetch path (no CORS on Bedrock endpoints), so every
+ * request flows through this server code.
+ */
+export function bedrockModelAllowed(modelId: string): boolean {
+  if (!env.BEDROCK_MODEL_ALLOWLIST) return true;
+  const allowed = env.BEDROCK_MODEL_ALLOWLIST.split(',').map(id => id.trim()).filter(Boolean);
+  if (!allowed.length) return true;
+  return allowed.includes(modelId) || allowed.includes(modelId.replace(_ALLOWLIST_REGION_PREFIX_RE, ''));
+}
+
+
 // --- URLs ---
 
 export function bedrockURLControlPlane(region: string, path: string): string {

--- a/src/modules/llms/server/listModels.dispatch.ts
+++ b/src/modules/llms/server/listModels.dispatch.ts
@@ -16,7 +16,7 @@ import { llmsAntFuseModelKnowledge, llmsAntInjectVariants, llmsAntValidateModelD
 import { ANTHROPIC_API_PATHS, anthropicAccess } from './anthropic/anthropic.access';
 
 // protocol: Bedrock
-import { bedrockAccessAsync, bedrockResolveRegion, bedrockURLControlPlane, bedrockURLMantle } from './bedrock/bedrock.access';
+import { bedrockAccessAsync, bedrockModelAllowed, bedrockResolveRegion, bedrockURLControlPlane, bedrockURLMantle } from './bedrock/bedrock.access';
 import { bedrockModelsToDescriptions, BedrockWire_API_Models_List } from './bedrock/bedrock.models';
 
 // protocol: Gemini
@@ -203,7 +203,9 @@ function _listModelsCreateDispatch(access: AixAPI_Access, signal?: AbortSignal):
           };
         },
         convertToDescriptions: ({ foundationModels, inferenceProfiles, mantleModelIds }) =>
-          bedrockModelsToDescriptions(foundationModels, inferenceProfiles, mantleModelIds),
+          bedrockModelsToDescriptions(foundationModels, inferenceProfiles, mantleModelIds)
+            // server-side model allowlist (BEDROCK_MODEL_ALLOWLIST) - pass-through when unset
+            .filter(model => bedrockModelAllowed(model.id)),
       });
     }
 

--- a/src/server/env.server.ts
+++ b/src/server/env.server.ts
@@ -59,6 +59,7 @@ export const env = createEnv({
     BEDROCK_SECRET_ACCESS_KEY: z.string().optional(),
     BEDROCK_SESSION_TOKEN: z.string().optional(), // required with the other 2 on corporate accounts sometimes
     BEDROCK_REGION: z.string().optional(),
+    BEDROCK_MODEL_ALLOWLIST: z.string().optional(), // comma-separated model IDs; matches full or region-prefix-stripped IDs; unset = all models
 
     // LLM: Cerebras
     CEREBRAS_API_KEY: z.string().optional(),


### PR DESCRIPTION
## What

Optional server-side model allowlist for AWS Bedrock: `BEDROCK_MODEL_ALLOWLIST` (comma-separated model IDs) controls which Bedrock models are listed to clients and accepted for chat generation. Unset or empty = current behavior, all models.

## Why

Enterprise and governed deployments need admin-controlled model catalogs: compliance teams approve specific models, not a provider's entire inventory (54+ models on Bedrock Mantle alone, growing every month). IAM policy can restrict invocation on the AWS side, but users would still see — and try, and get errors from — every listed model. This gives deployers a one-line server-side switch for the catalog their users actually see.

## How

- **`env.server.ts` / `docs/environment-variables.md`**: new optional `BEDROCK_MODEL_ALLOWLIST`.
- **`bedrock.access.ts`**: `bedrockModelAllowed(modelId)` — an entry matches a model by its **full ID** or by its **region-prefix-stripped base ID**, so one base entry (e.g. `anthropic.claude-sonnet-5`) covers the foundation model, its `us.`/`eu.`/`global.`/`jp.`/`apac.` inference profiles, and the Mantle variant; a prefixed entry (e.g. `us.amazon.nova-pro-v1:0`) admits just that profile.
- **Enforcement 1 — listing** (`listModels.dispatch.ts`, bedrock case): descriptions are filtered after conversion, so disallowed models never reach any client.
- **Enforcement 2 — generation** (`chatGenerate.dispatch.ts`, bedrock dialect): requests for disallowed model IDs are rejected with a clear error ("Model 'X' is not enabled on this server. Ask your administrator…"), so a crafted request can't bypass the listing filter.

The enforcement is effective rather than cosmetic: the Bedrock vendor has no client-side-fetch path (no CORS on Bedrock endpoints), so every listing and generation flows through this server code. Scope is strictly the Bedrock dialect — other vendors (including user-keyed services) are untouched.

## Tested

Live against Bedrock us-east-1:

- Allowlist `anthropic.claude-sonnet-5, zai.glm-4.7-flash,us.amazon.nova-pro-v1:0` (note the whitespace — trimming verified): listing returns exactly the 6 matching descriptions — both Claude region profiles plus their thinking variants (base-ID match), the GLM foundation+Mantle description, and only the `us.` Nova profile (prefixed match excludes the bare foundation model) ✅
- Chats pass on all three allowed models across the three Bedrock API paths (invoke-anthropic, mantle, converse) ✅
- Crafted requests for disallowed IDs (`us.anthropic.claude-fable-5`, bare `amazon.nova-pro-v1:0`) are rejected server-side with the admin-hint error ✅
- Variable unset: full 140-model listing and all chats unchanged — zero behavior change ✅
- `tsc --noEmit` clean, `next build` passes
