### PR TITLE
WebSearch: add Brave Search as a server-configured provider

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -55,6 +55,7 @@ PUPPETEER_WSS_ENDPOINT=
 # Search
 GOOGLE_CLOUD_API_KEY=
 GOOGLE_CSE_ID=
+BRAVE_SEARCH_API_KEY=
 
 # Text-To-Speech: ElevenLabs
 ELEVENLABS_API_KEY=
@@ -135,7 +136,8 @@ Enable the app to Talk, Draw, and Google things up.
 | `ELEVENLABS_API_HOST`      | Custom host for ElevenLabs                                                                                              |
 | `ELEVENLABS_VOICE_ID`      | Default voice ID for ElevenLabs                                                                                         |
 |                            | *Note: OpenAI TTS and LocalAI TTS reuse credentials from your configured LLM services (no separate env vars needed)*   |
-| **Google Custom Search**   | [Google Programmable Search Engine](https://programmablesearchengine.google.com/about/)  produces links to pages        |
+| **Web Search**             | Web search produces links to pages, used with the '/react' command                                                      |
+| `BRAVE_SEARCH_API_KEY`     | [Brave Search API](https://brave.com/search/api/) key - preferred over Google CSE when both are set (Google is sunsetting whole-web Programmable Search Engines) |
 | `GOOGLE_CLOUD_API_KEY`     | Google Cloud API Key, used with the '/react' command - [Link to GCP](https://console.cloud.google.com/apis/credentials) |
 | `GOOGLE_CSE_ID`            | Google Custom/Programmable Search Engine ID - [Link to PSE](https://programmablesearchengine.google.com/)               |
 | **Browse**                 |                                                                                                                         |

--- a/src/modules/backend/backend.router.ts
+++ b/src/modules/backend/backend.router.ts
@@ -69,6 +69,7 @@ export const backendRouter = createTRPCRouter({
         // others
         hasDB: (!!env.MDB_URI) || (!!env.POSTGRES_PRISMA_URL && !!env.POSTGRES_URL_NON_POOLING),
         hasBrowsing: !!env.PUPPETEER_WSS_ENDPOINT,
+        hasBraveSearch: !!env.BRAVE_SEARCH_API_KEY,
         hasGoogleCustomSearch: !!env.GOOGLE_CSE_ID && !!env.GOOGLE_CLOUD_API_KEY,
         hasVoiceElevenLabs: !!env.ELEVENLABS_API_KEY,
         // hashes

--- a/src/modules/backend/store-backend-capabilities.ts
+++ b/src/modules/backend/store-backend-capabilities.ts
@@ -29,6 +29,7 @@ export interface BackendCapabilities {
   // others
   hasDB: boolean;
   hasBrowsing: boolean;
+  hasBraveSearch: boolean;
   hasGoogleCustomSearch: boolean;
   hasVoiceElevenLabs: boolean;
   // hashes
@@ -70,6 +71,7 @@ const useBackendCapabilitiesStore = create<BackendStore>()(
     hasLlmXAI: false,
     hasDB: false,
     hasBrowsing: false,
+    hasBraveSearch: false,
     hasGoogleCustomSearch: false,
     hasVoiceElevenLabs: false,
     hashLlmReconfig: '',

--- a/src/modules/google/GoogleSearchSettings.tsx
+++ b/src/modules/google/GoogleSearchSettings.tsx
@@ -18,7 +18,8 @@ import { useGoogleSearchStore } from './store-module-google';
 export function GoogleSearchSettings() {
 
   // external state
-  const backendHasGoogle = getBackendCapabilities().hasGoogleCustomSearch;
+  const { hasGoogleCustomSearch, hasBraveSearch } = getBackendCapabilities();
+  const backendHasGoogle = hasGoogleCustomSearch || hasBraveSearch; // Brave server-side also fulfills web search - Google keys become optional overrides
   const { googleCloudApiKey, setGoogleCloudApiKey, googleCSEId, setGoogleCSEId, restrictToDomain, setRestrictToDomain } = useGoogleSearchStore(useShallow(state => ({
     googleCloudApiKey: state.googleCloudApiKey, setGoogleCloudApiKey: state.setGoogleCloudApiKey,
     googleCSEId: state.googleCSEId, setGoogleCSEId: state.setGoogleCSEId,
@@ -43,6 +44,12 @@ export function GoogleSearchSettings() {
     <Typography level='body-sm'>
       For custom search engines or domain-specific searches. Most models have native search capabilities. Uses the Google <ExternalLink href='https://developers.google.com/custom-search/v1/overview'>Programmable Search Engine</ExternalLink> API.
     </Typography>
+
+    {hasBraveSearch && (
+      <Typography level='body-sm'>
+        This server is configured with <ExternalLink href='https://brave.com/search/api/'>Brave Search</ExternalLink>, which is used automatically. The Google keys below are optional overrides.
+      </Typography>
+    )}
 
     <FormControl orientation='horizontal' sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
       <FormLabelStart title='GCP API Key'

--- a/src/modules/google/search.router.ts
+++ b/src/modules/google/search.router.ts
@@ -17,7 +17,12 @@ const GROUNDING_PER_URL_TIMEOUT_MS = 4000;
 export const googleSearchRouter = createTRPCRouter({
 
   /**
-   * Google Search via the Google Programmable Search product
+   * Web Search: Google Programmable Search, or Brave Search when server-configured.
+   *
+   * Provider selection: client-provided Google keys take precedence (explicit user
+   * configuration), otherwise a server-side BRAVE_SEARCH_API_KEY is preferred over
+   * server-side Google CSE keys - Google is sunsetting whole-web Programmable
+   * Search Engines, so Brave is the forward path when both are configured.
    */
   search: publicProcedure
     .input(z.object({
@@ -29,6 +34,12 @@ export const googleSearchRouter = createTRPCRouter({
     }))
     .query(async ({ input }): Promise<{ pages: Search.API.BriefResult[] }> => {
 
+      // [Brave] server-side, unless the client explicitly configured Google keys
+      const clientHasGoogleKeys = !!input.key?.trim() && !!input.cx?.trim();
+      if (!clientHasGoogleKeys && env.BRAVE_SEARCH_API_KEY)
+        return _braveSearch(env.BRAVE_SEARCH_API_KEY, input.query, input.items, input.restrictToDomain);
+
+      // [Google] client keys, or server CSE keys
       const customSearchParams: Search.Wire.RequestParams = {
         q: input.query.trim(),
         cx: (input.cx || env.GOOGLE_CSE_ID || '').trim(),
@@ -103,4 +114,44 @@ function objectToQueryString(params: Record<string, any>): string {
   return Object.entries(params)
     .map(([key, value]) => encodeURIComponent(key) + '=' + encodeURIComponent(value))
     .join('&');
+}
+
+
+/// Brave Search - https://api-dashboard.search.brave.com/app/documentation/web-search/get-started ///
+
+const BRAVE_MAX_RESULTS = 20; // Brave caps `count` at 20 (Google caps `num` at 10)
+
+async function _braveSearch(apiKey: string, query: string, items: number, restrictToDomain: string | null): Promise<{ pages: Search.API.BriefResult[] }> {
+
+  // domain restriction: no dedicated parameter in the Brave API, use the `site:` query operator
+  const q = (restrictToDomain ? `${query.trim()} site:${restrictToDomain.trim()}` : query.trim());
+
+  const params = new URLSearchParams({
+    q,
+    count: String(Math.min(Math.max(Math.round(items), 1), BRAVE_MAX_RESULTS)),
+  });
+
+  const data: Search.Wire.Brave.SearchResponse = await fetchJsonOrTRPCThrow({
+    url: `https://api.search.brave.com/res/v1/web/search?${params.toString()}`,
+    name: 'Brave Search',
+    headers: {
+      'Accept': 'application/json',
+      'Accept-Encoding': 'gzip',
+      'X-Subscription-Token': apiKey,
+    },
+  });
+
+  return {
+    pages: (data.web?.results || []).map((result): Search.API.BriefResult => ({
+      title: _braveStripHtml(result.title || ''),
+      link: result.url,
+      snippet: _braveStripHtml(result.description || ''), // Google snippets are plain text; Brave descriptions carry highlight markup
+    })),
+  };
+}
+
+function _braveStripHtml(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#x?0*(27|39);/g, '\'');
 }

--- a/src/modules/google/search.types.ts
+++ b/src/modules/google/search.types.ts
@@ -18,6 +18,27 @@ export namespace Search {
   // This is the upstream API [rev-eng on 2023-04-27], for Server (Next.js) -> Upstream Server
   export namespace Wire {
 
+    // Brave Search API - https://api-dashboard.search.brave.com/app/documentation/web-search/responses
+    export namespace Brave {
+
+      export interface SearchResponse {
+        // type: 'search';
+        web?: {
+          // type: 'search';
+          results?: Result[];
+        };
+        // query, mixed, videos, news, ... omitted - we only consume web results
+      }
+
+      export interface Result {
+        title: string; // may contain highlight markup (<strong>...</strong>) and HTML entities
+        url: string;
+        description?: string; // may contain highlight markup and HTML entities
+        // page_age, profile, language, family_friendly, thumbnail, ... omitted
+      }
+
+    }
+
     // https://developers.google.com/custom-search/v1/reference/rest/v1/cse/list
     export interface RequestParams {
       key: string; // API key

--- a/src/server/env.server.ts
+++ b/src/server/env.server.ts
@@ -113,6 +113,9 @@ export const env = createEnv({
     GOOGLE_CLOUD_API_KEY: z.string().optional(),
     GOOGLE_CSE_ID: z.string().optional(),
 
+    // Brave Search API - preferred over Google CSE when both are set (Google is sunsetting whole-web Programmable Search Engines)
+    BRAVE_SEARCH_API_KEY: z.string().optional(),
+
 
     // Text-To-Speech: ElevenLabs - speech.ts
     ELEVENLABS_API_KEY: z.string().optional(),


### PR DESCRIPTION
## Why — Google is sunsetting whole-web Programmable Search Engines

Per the Programmable Search Engine blog (Jan 2026), creating new **whole-web** Programmable Search Engines has been blocked since January 2026, and existing whole-web engines must transition off by **2027-01-01**. That is exactly the configuration big-AGI's web search uses: every deployment with `GOOGLE_CLOUD_API_KEY` + `GOOGLE_CSE_ID` doing whole-web search (the `/react` flow's `search` action) loses its provider within the year. Domain-restricted engines survive, but the general "search the web" use case needs a replacement path.

## What

Adds the [Brave Search API](https://brave.com/search/api/) (`api.search.brave.com/res/v1/web/search`, `X-Subscription-Token` auth) as a server-configured web search provider behind the existing abstraction — one new env var, zero client protocol changes.

- **`BRAVE_SEARCH_API_KEY`** server env var (documented in `docs/environment-variables.md`) + new **`hasBraveSearch`** backend capability.
- The `googleSearch.search` tRPC procedure selects the provider server-side and keeps returning the same provider-neutral `BriefResult[]` pages — the `/react` flow and all client code are untouched.
- **Selection order**: client-provided Google keys keep priority (explicit user configuration), then server-side Brave, then server-side Google CSE. Brave is deliberately preferred over server Google since Google's product is being sunset.
- **Fidelity**: domain restriction maps to Brave's `site:` query operator; Brave's highlight markup (`<strong>`) and HTML entities are stripped so snippets remain plain text, matching Google's output shape.
- **Settings UI**: when the server has Brave configured, the search settings treat search as backend-fulfilled (Google fields become optional overrides, with an explanatory note).

## Behavior guarantees

- **Unset = dormant**: without `BRAVE_SEARCH_API_KEY`, nothing changes — verified that capabilities and the search endpoint behave byte-for-byte as before (including the exact same error when no provider is configured).
- Existing Google-only deployments are unaffected; users with their own Google keys in the UI keep using them even if the server has Brave.

## Tested (live against the Brave API)

- Whole-web queries return correct pages with clean plain-text snippets ✅
- `restrictToDomain` returns only results from the requested domain (via `site:`) ✅
- Client-provided Google keys still route to Google (override verified) ✅
- Both server providers configured → Brave is used ✅
- No providers configured → stock error, zero behavior change ✅
- `tsc --noEmit` clean, `next build` passes

## Follow-up candidates

Tavily (and similar search APIs) can slot into the same server-side selection with the same `BriefResult` mapping; this PR deliberately implements Brave only.
