### PR TITLE
AIX: OpenAI Responses - parse MCP output items and streaming events

### DIFF
--- a/src/modules/aix/server/dispatch/chatGenerate/parsers/openai.responses.parser.ts
+++ b/src/modules/aix/server/dispatch/chatGenerate/parsers/openai.responses.parser.ts
@@ -474,6 +474,11 @@ export function createOpenAIResponsesEventParser(vendor: 'openai' | 'xai'): Chat
           if (messagePhase === 'commentary' || messagePhase === 'final_answer')
             pt.sendSetVendorState({ p: 'svs', vendor: vendor, state: { messagePhase } });
         }
+
+        // -> MCP: announce the server-side tool call as it starts - the added item carries the
+        //    tool name, which the subsequent response.mcp_call.* status events do not
+        if (event.item.type === 'mcp_call')
+          pt.sendOperationState(_mcpOperationType(event.item.name), `Calling ${_mcpToolDisplayName(event.item.name)}...`, { opId: event.item.id });
         break;
 
       case 'response.output_item.done':
@@ -570,11 +575,19 @@ export function createOpenAIResponsesEventParser(vendor: 'openai' | 'xai'): Chat
             _forwardDoneCustomToolCallItem(pt, doneItem, doneItem.id);
             break;
 
+          case 'mcp_list_tools':
+            // -> MCP-LT: tool discovery is bookkeeping - nothing to surface
+            break;
+
+          case 'mcp_call':
+            // -> MCP-C: close the server-side tool call placeholder with the outcome
+            _forwardDoneMCPCallItem(pt, doneItem);
+            break;
+
           default:
             const _exhaustiveCheck: never = doneItemType;
             // noinspection FallThroughInSwitchStatementJS
             // case 'file_search_call': // OpenAI vector store - not implemented
-            // case 'mcp_call':
             // TODO: Implement these when types are properly integrated
             aixResilientUnknownValue('OpenAI-Responses', `outputItemType:${doneItemType}`, doneItem);
             break;
@@ -769,6 +782,40 @@ export function createOpenAIResponsesEventParser(vendor: 'openai' | 'xai'): Chat
         R.outputItemVisit(eventType, event.output_index, 'code_interpreter_call');
         pt.sendOperationState('code-exec', 'Code executed', { opId: event.item_id, state: 'done' });
         // -> Final result is handled in response.output_item.done
+        break;
+
+      // 4.x - MCP Events (server-side tools: OpenAI remote MCP, Bedrock Mantle mcp connectors)
+      // Flow: mcp_list_tools: in_progress -> completed|failed
+      //       mcp_call: in_progress -> [arguments.delta]* -> arguments.done -> completed|failed
+      // NOTE: the 'Calling <tool>...' placeholder is sent at response.output_item.added (which has the tool name)
+
+      case 'response.mcp_list_tools.in_progress':
+      case 'response.mcp_list_tools.completed':
+        R.outputItemVisit(eventType, event.output_index, 'mcp_list_tools');
+        // silent: tool discovery is bookkeeping, not worth a placeholder
+        break;
+
+      case 'response.mcp_list_tools.failed':
+        R.outputItemVisit(eventType, event.output_index, 'mcp_list_tools');
+        // surface the failure - the model will proceed without the tools, and the user should know why
+        console.log('[DEV] AIX: OpenAI Responses: MCP tools listing failed');
+        break;
+
+      case 'response.mcp_call.in_progress':
+      case 'response.mcp_call_arguments.delta':
+        R.outputItemVisit(eventType, event.output_index, 'mcp_call');
+        // in_progress: placeholder already sent at output_item.added; deltas: we don't stream partial arguments
+        break;
+
+      case 'response.mcp_call_arguments.done':
+        R.outputItemVisit(eventType, event.output_index, 'mcp_call');
+        // Arguments complete - final handling (with name + output) in output_item.done
+        break;
+
+      case 'response.mcp_call.completed':
+      case 'response.mcp_call.failed':
+        R.outputItemVisit(eventType, event.output_index, 'mcp_call');
+        // -> Final result (or error) is handled in response.output_item.done, which carries name/arguments/error
         break;
 
       // 4.x - Custom Tool Call Events
@@ -1120,6 +1167,16 @@ export function createOpenAIResponseParserNS(vendor: 'openai' | 'xai'): ChatGene
           pt.endMessagePart();
           break;
 
+        case 'mcp_list_tools':
+          // -> MCP-LT: tool discovery is bookkeeping - nothing to surface
+          break;
+
+        case 'mcp_call':
+          // -> MCP-C: surface the completed server-side tool call
+          _forwardDoneMCPCallItem(pt, oItem);
+          pt.endMessagePart();
+          break;
+
         default:
           const _exhaustiveCheck: never = oItemType;
           aixResilientUnknownValue('OpenAI-Responses-NS', 'outputItemType', oItemType);
@@ -1343,6 +1400,49 @@ function _forwardDoneWebSearchCallItem(pt: IParticleTransmitter, webSearchCall: 
       console.log(`[DEV] AIX: Unknown web_search_call action:`, { action });
       break;
   }
+}
+
+/** MCP tool display name: strip the gateway/server prefix, e.g. 'web-search___WebSearch' (AgentCore Gateway target___tool) -> 'WebSearch' */
+function _mcpToolDisplayName(name: string | undefined): string {
+  if (!name) return 'MCP tool';
+  return name.split('___').pop() || name;
+}
+
+/** Placeholder affordance for MCP tools: search-like tools reuse the web-search rendering; others show as executions (no dedicated MCP renderer yet) */
+function _mcpOperationType(name: string | undefined): 'search-web' | 'code-exec' {
+  return /search/i.test(name || '') ? 'search-web' : 'code-exec';
+}
+
+/**
+ * Processes a completed (or failed) MCP call item and closes its placeholder.
+ * MCP calls are executed server-side by the API provider (OpenAI remote MCP servers,
+ * AWS Bedrock Mantle 'mcp' connectors); we only surface name, arguments and outcome.
+ */
+function _forwardDoneMCPCallItem(pt: IParticleTransmitter, mcpCall: Extract<OpenAIWire_API_Responses.Response['output'][number], { type: 'mcp_call' }>): void {
+  const { id: opId, name, arguments: mcpArguments, error: mcpError, status } = mcpCall;
+  const displayName = _mcpToolDisplayName(name);
+  const mot = _mcpOperationType(name);
+
+  // failed call -> error placeholder
+  if (mcpError || status === 'failed') {
+    const errorSuffix = mcpError ? `: ${String(mcpError).slice(0, 200)}` : '';
+    pt.sendOperationState(mot, `${displayName} error${errorSuffix}`, { opId, state: 'error' });
+    return;
+  }
+
+  // completed call -> summarize with the query when the arguments carry one (common for search tools)
+  let doneText = `${displayName} completed`;
+  let iTexts: string[] | undefined = undefined;
+  try {
+    const parsedArgs = JSON.parse(mcpArguments || '{}');
+    if (parsedArgs && typeof parsedArgs.query === 'string' && parsedArgs.query) {
+      doneText += `: ${parsedArgs.query}`;
+      iTexts = [parsedArgs.query];
+    }
+  } catch {
+    // non-JSON arguments: ignore, keep the generic done text
+  }
+  pt.sendOperationState(mot, doneText, { opId, state: 'done', ...(iTexts ? { iTexts } : {}) });
 }
 
 /**

--- a/src/modules/aix/server/dispatch/wiretypes/openai.wiretypes.ts
+++ b/src/modules/aix/server/dispatch/wiretypes/openai.wiretypes.ts
@@ -1236,6 +1236,35 @@ export namespace OpenAIWire_Responses_Items {
     }),
   });
 
+  // MCP items: server-side tool calls (OpenAI 'remote MCP servers', AWS Bedrock Mantle 'mcp' connectors)
+  // executed by the API provider; the client only observes discovery and call items.
+
+  const OutputMCPListToolsItem_schema = _OutputItemBase_schema.extend({
+    type: z.literal('mcp_list_tools'),
+    id: z.string(), // unique ID of the output item, e.g. mcpl_...
+    server_label: z.string().optional(), // echo of the tools[].server_label from the request
+    tools: z.array(z.object({
+      name: z.string(),
+      description: z.string().nullish(),
+      input_schema: z.any().optional(), // JSON schema of the tool input - unused
+      annotations: z.any().nullish(), // unused
+    })).optional(), // empty on .added, populated on .done
+    error: z.string().nullish(), // populated when the listing failed
+  });
+
+  const OutputMCPCallItem_schema = _OutputItemBase_schema.extend({
+    type: z.literal('mcp_call'),
+    id: z.string(), // unique ID of the output item, e.g. mc_...
+    name: z.string(), // tool name, e.g. 'web-search___WebSearch' (AgentCore Gateway: target___tool)
+    server_label: z.string().optional(),
+    arguments: z.string().optional(), // JSON string, complete on .done ('' on .added)
+    output: z.string().nullish(), // JSON string of the tool output, when completed
+    error: z.string().nullish(), // error message, when failed
+    approval_request_id: z.string().nullish(), // unused: we only dispatch require_approval: 'never'
+    // redefining to add 'failed' (per OpenAI spec) and 'calling' (defensive)
+    status: z.enum(['in_progress', 'completed', 'incomplete', 'calling', 'failed']).optional(),
+  });
+
   const OutputImageGenerationCallItem_schema = _OutputItemBase_schema.extend({
     type: z.literal('image_generation_call'),
     id: z.string(), // unique ID of the image generation call (output item ID)
@@ -1322,17 +1351,16 @@ export namespace OpenAIWire_Responses_Items {
     OutputWebSearchCallItem_schema, // xAI/OpenAI
     OutputCodeInterpreterCallItem_schema, // OpenAI/xAI
     OutputCustomToolCallItem_schema, // xAI x_search uses this (x_user_search, etc.)
+    OutputMCPCallItem_schema, // OpenAI remote MCP / Bedrock Mantle mcp connectors
+    OutputMCPListToolsItem_schema,
 
     // Additional output items to be added later:
     // XAI: x_search_call = not documented, will need rev-eng
 
     // OutputFileSearchCallItem_schema,
-    // OutputMCPCallItem_schema,
     // ComputerUseCallOutput_schema,
     // CodeInterpreterCallOutput_schema,
     // LocalShellCallOutput_schema,
-    // MCPToolCallOutput_schema,
-    // MCPListToolsOutput_schema,
     // MCPApprovalRequestOutput_schema,
 
   ]);
@@ -1927,41 +1955,43 @@ export namespace OpenAIWire_API_Responses {
     type: z.literal('response.image_generation_call.completed'),
   });
 
-  // Streaming > Tool invoke > Host MCP events (basic implementation)
+  // Streaming > Tool invoke > Host MCP events
+  // Flow (observed live on Bedrock Mantle, 2026-07-20): mcp_list_tools: in_progress -> completed|failed;
+  // mcp_call: in_progress -> [mcp_call_arguments.delta]* -> mcp_call_arguments.done -> completed|failed
 
-  // const OutputMCPCallInProgressEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_call.in_progress'),
-  // });
+  const OutputMCPCallInProgressEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_call.in_progress'),
+  });
 
-  // const OutputMCPCallCompletedEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_call.completed'),
-  // });
+  const OutputMCPCallCompletedEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_call.completed'),
+  });
 
-  // const OutputMCPCallFailedEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_call.failed'),
-  // });
+  const OutputMCPCallFailedEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_call.failed'),
+  });
 
-  // const OutputMCPCallArgumentsDeltaEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_call_arguments.delta'),
-  //   delta: z.string(),
-  // });
+  const OutputMCPCallArgumentsDeltaEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_call_arguments.delta'),
+    delta: z.string(),
+  });
 
-  // const OutputMCPCallArgumentsDoneEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_call_arguments.done'),
-  //   arguments: z.string(),
-  // });
+  const OutputMCPCallArgumentsDoneEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_call_arguments.done'),
+    arguments: z.string(), // JSON string of the tool call arguments
+  });
 
-  // const OutputMCPListToolsInProgressEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_list_tools.in_progress'),
-  // });
+  const OutputMCPListToolsInProgressEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_list_tools.in_progress'),
+  });
 
-  // const OutputMCPListToolsCompletedEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_list_tools.completed'),
-  // });
+  const OutputMCPListToolsCompletedEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_list_tools.completed'),
+  });
 
-  // const OutputMCPListToolsFailedEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_list_tools.failed'),
-  // });
+  const OutputMCPListToolsFailedEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_list_tools.failed'),
+  });
 
   // Streaming > Tool invoke > Host Code interpreter events (xAI/OpenAI)
 
@@ -2084,14 +2114,14 @@ export namespace OpenAIWire_API_Responses {
     OutputImageGenerationCallCompletedEvent_schema,
 
     // Host Tool invoke > MCP events
-    // OutputMCPCallArgumentsDeltaEvent_schema,
-    // OutputMCPCallArgumentsDoneEvent_schema,
-    // OutputMCPCallInProgressEvent_schema,
-    // OutputMCPCallCompletedEvent_schema,
-    // OutputMCPCallFailedEvent_schema,
-    // OutputMCPListToolsInProgressEvent_schema,
-    // OutputMCPListToolsCompletedEvent_schema,
-    // OutputMCPListToolsFailedEvent_schema,
+    OutputMCPCallArgumentsDeltaEvent_schema,
+    OutputMCPCallArgumentsDoneEvent_schema,
+    OutputMCPCallInProgressEvent_schema,
+    OutputMCPCallCompletedEvent_schema,
+    OutputMCPCallFailedEvent_schema,
+    OutputMCPListToolsInProgressEvent_schema,
+    OutputMCPListToolsCompletedEvent_schema,
+    OutputMCPListToolsFailedEvent_schema,
 
     // Host Tool invoke > Code Interpreter events (xAI/OpenAI)
     OutputCodeInterpreterCallInProgressEvent_schema,


### PR DESCRIPTION
## What

Implements the MCP output items (`mcp_call`, `mcp_list_tools`) and the eight `response.mcp_*` streaming events in the OpenAI Responses wiretypes and parser — completing the stubs that were already scaffolded in both files ("TODO: Implement these when types are properly integrated").

## Why

Server-side MCP tool calls are part of the OpenAI Responses API ("remote MCP servers", tools of `type: "mcp"`), and other Responses-compatible providers reuse the same wire shapes (AWS Bedrock Mantle's server-side tool connectors, for example). Today these items fall into the resilient unknown-value path: the upstream tool loop works, the model answers, but the user sees no indication that tools ran.

## How

- **wiretypes**: `OutputMCPCallItem` / `OutputMCPListToolsItem` schemas added to the `OutputItem` union; `response.mcp_call.{in_progress,completed,failed}`, `response.mcp_call_arguments.{delta,done}`, `response.mcp_list_tools.{in_progress,completed,failed}` added to the `StreamingEvent` union. Field shapes validated against live SSE captures from a Responses-compatible endpoint (2026-07-20), including the `mcp_call` status extension (`failed`, `calling`).
- **parser (streaming)**: the `Calling <tool>…` placeholder is emitted at `response.output_item.added` — the only MCP event carrying the tool name; the `response.mcp_*` status events are acknowledged through the state machine; the final outcome closes the placeholder at `output_item.done` (tool name + query when the arguments carry one; error state on `error`/`status: 'failed'`).
- **parser (non-streaming)**: same outcome rendering from the complete response.
- **rendering**: reuses the existing hosted-tool placeholders — search-like tool names map to the `search-web` affordance, others to `code-exec`. A dedicated MCP affordance can follow later without wire changes.
- `mcp_list_tools` (discovery) is deliberately silent.

## Behavior guarantees

No change for requests that don't produce MCP items. Requests that do: previously silent (unknown-value telemetry), now rendered.

## Tested

Live against a Responses endpoint with server-side MCP tools (streaming + non-streaming): placeholder appears when the call starts, closes with the tool name and search query on completion, and the message text follows normally. `tsc --noEmit` clean, `next build` passes.
