### PR TITLE
Bedrock: AWS-native web search via server-side MCP tools (AgentCore Gateway)

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -34,6 +34,7 @@ BEDROCK_ACCESS_KEY_ID=
 BEDROCK_SECRET_ACCESS_KEY=
 BEDROCK_SESSION_TOKEN=
 BEDROCK_REGION=
+BEDROCK_AGENTCORE_GATEWAY_ARN=
 DEEPSEEK_API_KEY=
 GEMINI_API_KEY=
 GROQ_API_KEY=
@@ -109,6 +110,7 @@ requiring the user to enter an API key
 | `BEDROCK_SECRET_ACCESS_KEY` | AWS IAM Secret Access Key for Bedrock                                                                          | Optional, but if set `BEDROCK_ACCESS_KEY_ID` must also be set      |
 | `BEDROCK_SESSION_TOKEN`     | AWS Session Token for temporary/STS credentials                                                                | Optional                                                          |
 | `BEDROCK_REGION`            | AWS region for Bedrock (e.g., `us-east-1`, `us-west-2`, `eu-west-1`)                                          | Optional, defaults to `us-east-1`                                 |
+| `BEDROCK_AGENTCORE_GATEWAY_ARN` | ARN of an AgentCore Gateway for server-side MCP tools (e.g. the managed [Web Search Tool](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-target-connector-web-search-tool.html) connector). Adds a per-model Web Search toggle to Responses-capable Mantle models. The caller's IAM identity needs `bedrock-agentcore:InvokeGateway` on the gateway | Optional                                                          |
 | `DEEPSEEK_API_KEY`          | The API key for Deepseek AI                                                                                    | Optional                                                          |
 | `GEMINI_API_KEY`            | The API key for Google AI's Gemini                                                                             | Optional                                                          |
 | `GROQ_API_KEY`              | The API key for Groq Cloud                                                                                     | Optional                                                          |

--- a/src/common/stores/llms/llms.parameters.ts
+++ b/src/common/stores/llms/llms.parameters.ts
@@ -297,6 +297,14 @@ export const DModelParameterRegistry = {
     // undefined is not accepted when this parameter is used
   }),
 
+  llmVndBedrockWebSearch: _enumDef({ // implies: LLM_IF_Tools_WebSearch
+    label: 'Web Search',
+    type: 'enum',
+    description: 'AWS-native web search, executed server-side by Bedrock via the deployment\'s AgentCore Gateway',
+    values: ['auto'],
+    // undefined means off
+  }),
+
 
   // Gemini-specific
 

--- a/src/modules/aix/client/aix.client.ts
+++ b/src/modules/aix/client/aix.client.ts
@@ -74,7 +74,7 @@ export function aixCreateModelFromLLMOptions(
     llmRef, llmTemperature, llmResponseTokens, llmTopP, llmForceNoStream,
     llmVndAntEffort, llmVndGemEffort, llmVndOaiEffort, llmVndMiscEffort,
     llmVndAnt1MContext, llmVndAntCodeSandbox, llmVndAntInfSpeed, llmVndAntSkills, llmVndAntThinkingBudget, llmVndAntWebDynamic, llmVndAntWebFetch, llmVndAntWebFetchMaxUses, llmVndAntWebSearch, llmVndAntWebSearchMaxUses,
-    llmVndBedrockAPI,
+    llmVndBedrockAPI, llmVndBedrockWebSearch,
     llmVndGeminiAgentViz, llmVndGeminiAspectRatio, llmVndGeminiImageSize, llmVndGeminiCodeExecution, llmVndGeminiComputerUse, llmVndGeminiGoogleSearch, llmVndGeminiMediaResolution, llmVndGeminiThinkingBudget,
     // llmVndMoonshotWebSearch,
     llmVndOaiReasoningMode, llmVndOaiRestoreMarkdown, llmVndOaiVerbosity, llmVndOaiWebSearchContext, llmVndOaiWebSearchGeolocation, llmVndOaiImageGeneration, llmVndOaiCodeInterpreter,
@@ -148,6 +148,7 @@ export function aixCreateModelFromLLMOptions(
 
     // Bedrock
     ...(llmVndBedrockAPI ? { vndBedrockAPI: llmVndBedrockAPI } : {}),
+    ...(llmVndBedrockWebSearch === 'auto' ? { vndBedrockWebSearch: llmVndBedrockWebSearch } : {}),
 
     // Gemini
     ...(llmVndGeminiInteractions ? { vndGeminiAPI: 'interactions-agent' } : {}),

--- a/src/modules/aix/server/api/aix.wiretypes.ts
+++ b/src/modules/aix/server/api/aix.wiretypes.ts
@@ -528,6 +528,7 @@ export namespace AixWire_API {
 
     // Bedrock
     vndBedrockAPI: z.enum(['converse', 'invoke-anthropic', 'mantle', 'mantle-responses']).optional(),
+    vndBedrockWebSearch: z.enum(['auto']).optional(), // [mantle-responses only] AWS-native web search via the server-configured AgentCore Gateway
 
     // Gemini
     vndGeminiAPI: z.enum(['interactions-agent']).optional(), // opt-in per-model API dialect; unset = generateContent

--- a/src/modules/aix/server/dispatch/chatGenerate/chatGenerate.dispatch.ts
+++ b/src/modules/aix/server/dispatch/chatGenerate/chatGenerate.dispatch.ts
@@ -4,6 +4,7 @@ import { bedrockAccessAsync, bedrockResolveRegion, bedrockURLMantle, bedrockURLR
 import { geminiAccess } from '~/modules/llms/server/gemini/gemini.access';
 import { ollamaAccess } from '~/modules/llms/server/ollama/ollama.access';
 
+import { env } from '~/server/env.server';
 import { fetchResponseOrTRPCThrow, TRPCFetcherError } from '~/server/trpc/trpc.router.fetchers';
 
 import type { AixAPI_Access, AixAPI_Model, AixAPI_ResumeHandle, AixAPIChatGenerate_Request, AixWire_Particles } from '../../api/aix.wiretypes';
@@ -166,6 +167,18 @@ export async function createChatGenerateDispatch(access: AixAPI_Access, model: A
         case 'mantle-responses':
           const mantleResponsesUrl = bedrockURLMantle(bedrockResolveRegion(access), '/openai/v1/responses');
           const mantleResponsesBody = aixToOpenAIResponses('openai', model, chatGenerate, streaming, false /* no reattach support for the bedrock dialect, don't store upstream */);
+
+          // [opt-in] AWS-native web search: server-side MCP tool executed by Bedrock via the deployment's
+          // AgentCore Gateway (env-configured). Bedrock requires require_approval: 'never'.
+          if (model.vndBedrockWebSearch && env.BEDROCK_AGENTCORE_GATEWAY_ARN)
+            mantleResponsesBody.tools = [...(mantleResponsesBody.tools || []), {
+              type: 'mcp',
+              server_label: 'aws_web_search',
+              connector_id: env.BEDROCK_AGENTCORE_GATEWAY_ARN,
+              server_description: 'Web search over an AWS-managed index, for current information with cited sources',
+              require_approval: 'never',
+            }];
+
           return {
             request: {
               ...await bedrockAccessAsync(access, 'POST', mantleResponsesUrl, mantleResponsesBody),

--- a/src/modules/aix/server/dispatch/chatGenerate/parsers/openai.responses.parser.ts
+++ b/src/modules/aix/server/dispatch/chatGenerate/parsers/openai.responses.parser.ts
@@ -478,6 +478,11 @@ export function createOpenAIResponsesEventParser(vendor: 'openai' | 'xai'): Chat
           if (messagePhase === 'commentary' || messagePhase === 'final_answer')
             pt.sendSetVendorState({ p: 'svs', vendor: vendor, state: { messagePhase } });
         }
+
+        // -> MCP: announce the server-side tool call as it starts - the added item carries the
+        //    tool name, which the subsequent response.mcp_call.* status events do not
+        if (event.item.type === 'mcp_call')
+          pt.sendOperationState(_mcpOperationType(event.item.name), `Calling ${_mcpToolDisplayName(event.item.name)}...`, { opId: event.item.id });
         break;
 
       case 'response.output_item.done':
@@ -574,11 +579,19 @@ export function createOpenAIResponsesEventParser(vendor: 'openai' | 'xai'): Chat
             _forwardDoneCustomToolCallItem(pt, doneItem, doneItem.id);
             break;
 
+          case 'mcp_list_tools':
+            // -> MCP-LT: tool discovery is bookkeeping - nothing to surface
+            break;
+
+          case 'mcp_call':
+            // -> MCP-C: close the server-side tool call placeholder with the outcome
+            _forwardDoneMCPCallItem(pt, doneItem);
+            break;
+
           default:
             const _exhaustiveCheck: never = doneItemType;
             // noinspection FallThroughInSwitchStatementJS
             // case 'file_search_call': // OpenAI vector store - not implemented
-            // case 'mcp_call':
             // TODO: Implement these when types are properly integrated
             aixResilientUnknownValue('OpenAI-Responses', `outputItemType:${doneItemType}`, doneItem);
             break;
@@ -788,6 +801,40 @@ export function createOpenAIResponsesEventParser(vendor: 'openai' | 'xai'): Chat
         R.outputItemVisit(eventType, event.output_index, 'code_interpreter_call');
         pt.sendOperationState('code-exec', 'Code executed', { opId: event.item_id, state: 'done' });
         // -> Final result is handled in response.output_item.done
+        break;
+
+      // 4.x - MCP Events (server-side tools: OpenAI remote MCP, Bedrock Mantle mcp connectors)
+      // Flow: mcp_list_tools: in_progress -> completed|failed
+      //       mcp_call: in_progress -> [arguments.delta]* -> arguments.done -> completed|failed
+      // NOTE: the 'Calling <tool>...' placeholder is sent at response.output_item.added (which has the tool name)
+
+      case 'response.mcp_list_tools.in_progress':
+      case 'response.mcp_list_tools.completed':
+        R.outputItemVisit(eventType, event.output_index, 'mcp_list_tools');
+        // silent: tool discovery is bookkeeping, not worth a placeholder
+        break;
+
+      case 'response.mcp_list_tools.failed':
+        R.outputItemVisit(eventType, event.output_index, 'mcp_list_tools');
+        // surface the failure - the model will proceed without the tools, and the user should know why
+        console.log('[DEV] AIX: OpenAI Responses: MCP tools listing failed');
+        break;
+
+      case 'response.mcp_call.in_progress':
+      case 'response.mcp_call_arguments.delta':
+        R.outputItemVisit(eventType, event.output_index, 'mcp_call');
+        // in_progress: placeholder already sent at output_item.added; deltas: we don't stream partial arguments
+        break;
+
+      case 'response.mcp_call_arguments.done':
+        R.outputItemVisit(eventType, event.output_index, 'mcp_call');
+        // Arguments complete - final handling (with name + output) in output_item.done
+        break;
+
+      case 'response.mcp_call.completed':
+      case 'response.mcp_call.failed':
+        R.outputItemVisit(eventType, event.output_index, 'mcp_call');
+        // -> Final result (or error) is handled in response.output_item.done, which carries name/arguments/error
         break;
 
       // 4.x - Custom Tool Call Events
@@ -1140,6 +1187,16 @@ export function createOpenAIResponseParserNS(vendor: 'openai' | 'xai'): ChatGene
           pt.endMessagePart();
           break;
 
+        case 'mcp_list_tools':
+          // -> MCP-LT: tool discovery is bookkeeping - nothing to surface
+          break;
+
+        case 'mcp_call':
+          // -> MCP-C: surface the completed server-side tool call
+          _forwardDoneMCPCallItem(pt, oItem);
+          pt.endMessagePart();
+          break;
+
         default:
           const _exhaustiveCheck: never = oItemType;
           aixResilientUnknownValue('OpenAI-Responses-NS', 'outputItemType', oItemType);
@@ -1363,6 +1420,49 @@ function _forwardDoneWebSearchCallItem(pt: IParticleTransmitter, webSearchCall: 
       console.log(`[DEV] AIX: Unknown web_search_call action:`, { action });
       break;
   }
+}
+
+/** MCP tool display name: strip the gateway/server prefix, e.g. 'web-search___WebSearch' (AgentCore Gateway target___tool) -> 'WebSearch' */
+function _mcpToolDisplayName(name: string | undefined): string {
+  if (!name) return 'MCP tool';
+  return name.split('___').pop() || name;
+}
+
+/** Placeholder affordance for MCP tools: search-like tools reuse the web-search rendering; others show as executions (no dedicated MCP renderer yet) */
+function _mcpOperationType(name: string | undefined): 'search-web' | 'code-exec' {
+  return /search/i.test(name || '') ? 'search-web' : 'code-exec';
+}
+
+/**
+ * Processes a completed (or failed) MCP call item and closes its placeholder.
+ * MCP calls are executed server-side by the API provider (OpenAI remote MCP servers,
+ * AWS Bedrock Mantle 'mcp' connectors); we only surface name, arguments and outcome.
+ */
+function _forwardDoneMCPCallItem(pt: IParticleTransmitter, mcpCall: Extract<OpenAIWire_API_Responses.Response['output'][number], { type: 'mcp_call' }>): void {
+  const { id: opId, name, arguments: mcpArguments, error: mcpError, status } = mcpCall;
+  const displayName = _mcpToolDisplayName(name);
+  const mot = _mcpOperationType(name);
+
+  // failed call -> error placeholder
+  if (mcpError || status === 'failed') {
+    const errorSuffix = mcpError ? `: ${String(mcpError).slice(0, 200)}` : '';
+    pt.sendOperationState(mot, `${displayName} error${errorSuffix}`, { opId, state: 'error' });
+    return;
+  }
+
+  // completed call -> summarize with the query when the arguments carry one (common for search tools)
+  let doneText = `${displayName} completed`;
+  let iTexts: string[] | undefined = undefined;
+  try {
+    const parsedArgs = JSON.parse(mcpArguments || '{}');
+    if (parsedArgs && typeof parsedArgs.query === 'string' && parsedArgs.query) {
+      doneText += `: ${parsedArgs.query}`;
+      iTexts = [parsedArgs.query];
+    }
+  } catch {
+    // non-JSON arguments: ignore, keep the generic done text
+  }
+  pt.sendOperationState(mot, doneText, { opId, state: 'done', ...(iTexts ? { iTexts } : {}) });
 }
 
 /**

--- a/src/modules/aix/server/dispatch/wiretypes/openai.wiretypes.ts
+++ b/src/modules/aix/server/dispatch/wiretypes/openai.wiretypes.ts
@@ -1262,6 +1262,35 @@ export namespace OpenAIWire_Responses_Items {
     }),
   });
 
+  // MCP items: server-side tool calls (OpenAI 'remote MCP servers', AWS Bedrock Mantle 'mcp' connectors)
+  // executed by the API provider; the client only observes discovery and call items.
+
+  const OutputMCPListToolsItem_schema = _OutputItemBase_schema.extend({
+    type: z.literal('mcp_list_tools'),
+    id: z.string(), // unique ID of the output item, e.g. mcpl_...
+    server_label: z.string().optional(), // echo of the tools[].server_label from the request
+    tools: z.array(z.object({
+      name: z.string(),
+      description: z.string().nullish(),
+      input_schema: z.any().optional(), // JSON schema of the tool input - unused
+      annotations: z.any().nullish(), // unused
+    })).optional(), // empty on .added, populated on .done
+    error: z.string().nullish(), // populated when the listing failed
+  });
+
+  const OutputMCPCallItem_schema = _OutputItemBase_schema.extend({
+    type: z.literal('mcp_call'),
+    id: z.string(), // unique ID of the output item, e.g. mc_...
+    name: z.string(), // tool name, e.g. 'web-search___WebSearch' (AgentCore Gateway: target___tool)
+    server_label: z.string().optional(),
+    arguments: z.string().optional(), // JSON string, complete on .done ('' on .added)
+    output: z.string().nullish(), // JSON string of the tool output, when completed
+    error: z.string().nullish(), // error message, when failed
+    approval_request_id: z.string().nullish(), // unused: we only dispatch require_approval: 'never'
+    // redefining to add 'failed' (per OpenAI spec) and 'calling' (defensive)
+    status: z.enum(['in_progress', 'completed', 'incomplete', 'calling', 'failed']).optional(),
+  });
+
   const OutputImageGenerationCallItem_schema = _OutputItemBase_schema.extend({
     type: z.literal('image_generation_call'),
     id: z.string(), // unique ID of the image generation call (output item ID)
@@ -1354,17 +1383,16 @@ export namespace OpenAIWire_Responses_Items {
     OutputWebSearchCallItem_schema, // xAI/OpenAI
     OutputCodeInterpreterCallItem_schema, // OpenAI/xAI
     OutputCustomToolCallItem_schema, // xAI x_search uses this (x_user_search, etc.)
+    OutputMCPCallItem_schema, // OpenAI remote MCP / Bedrock Mantle mcp connectors
+    OutputMCPListToolsItem_schema,
 
     // Additional output items to be added later:
     // XAI: x_search_call = not documented, will need rev-eng
 
     // OutputFileSearchCallItem_schema,
-    // OutputMCPCallItem_schema,
     // ComputerUseCallOutput_schema,
     // CodeInterpreterCallOutput_schema,
     // LocalShellCallOutput_schema,
-    // MCPToolCallOutput_schema,
-    // MCPListToolsOutput_schema,
     // MCPApprovalRequestOutput_schema,
 
   ]);
@@ -1959,41 +1987,43 @@ export namespace OpenAIWire_API_Responses {
     type: z.literal('response.image_generation_call.completed'),
   });
 
-  // Streaming > Tool invoke > Host MCP events (basic implementation)
+  // Streaming > Tool invoke > Host MCP events
+  // Flow (observed live on Bedrock Mantle, 2026-07-20): mcp_list_tools: in_progress -> completed|failed;
+  // mcp_call: in_progress -> [mcp_call_arguments.delta]* -> mcp_call_arguments.done -> completed|failed
 
-  // const OutputMCPCallInProgressEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_call.in_progress'),
-  // });
+  const OutputMCPCallInProgressEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_call.in_progress'),
+  });
 
-  // const OutputMCPCallCompletedEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_call.completed'),
-  // });
+  const OutputMCPCallCompletedEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_call.completed'),
+  });
 
-  // const OutputMCPCallFailedEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_call.failed'),
-  // });
+  const OutputMCPCallFailedEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_call.failed'),
+  });
 
-  // const OutputMCPCallArgumentsDeltaEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_call_arguments.delta'),
-  //   delta: z.string(),
-  // });
+  const OutputMCPCallArgumentsDeltaEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_call_arguments.delta'),
+    delta: z.string(),
+  });
 
-  // const OutputMCPCallArgumentsDoneEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_call_arguments.done'),
-  //   arguments: z.string(),
-  // });
+  const OutputMCPCallArgumentsDoneEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_call_arguments.done'),
+    arguments: z.string(), // JSON string of the tool call arguments
+  });
 
-  // const OutputMCPListToolsInProgressEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_list_tools.in_progress'),
-  // });
+  const OutputMCPListToolsInProgressEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_list_tools.in_progress'),
+  });
 
-  // const OutputMCPListToolsCompletedEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_list_tools.completed'),
-  // });
+  const OutputMCPListToolsCompletedEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_list_tools.completed'),
+  });
 
-  // const OutputMCPListToolsFailedEvent_schema = _OutputIndexedEvent_schema.extend({
-  //   type: z.literal('response.mcp_list_tools.failed'),
-  // });
+  const OutputMCPListToolsFailedEvent_schema = _OutputIndexedEvent_schema.extend({
+    type: z.literal('response.mcp_list_tools.failed'),
+  });
 
   // Streaming > Tool invoke > Host Code interpreter events (xAI/OpenAI)
 
@@ -2116,14 +2146,14 @@ export namespace OpenAIWire_API_Responses {
     OutputImageGenerationCallCompletedEvent_schema,
 
     // Host Tool invoke > MCP events
-    // OutputMCPCallArgumentsDeltaEvent_schema,
-    // OutputMCPCallArgumentsDoneEvent_schema,
-    // OutputMCPCallInProgressEvent_schema,
-    // OutputMCPCallCompletedEvent_schema,
-    // OutputMCPCallFailedEvent_schema,
-    // OutputMCPListToolsInProgressEvent_schema,
-    // OutputMCPListToolsCompletedEvent_schema,
-    // OutputMCPListToolsFailedEvent_schema,
+    OutputMCPCallArgumentsDeltaEvent_schema,
+    OutputMCPCallArgumentsDoneEvent_schema,
+    OutputMCPCallInProgressEvent_schema,
+    OutputMCPCallCompletedEvent_schema,
+    OutputMCPCallFailedEvent_schema,
+    OutputMCPListToolsInProgressEvent_schema,
+    OutputMCPListToolsCompletedEvent_schema,
+    OutputMCPListToolsFailedEvent_schema,
 
     // Host Tool invoke > Code Interpreter events (xAI/OpenAI)
     OutputCodeInterpreterCallInProgressEvent_schema,

--- a/src/modules/aix/server/dispatch/wiretypes/openai.wiretypes.ts
+++ b/src/modules/aix/server/dispatch/wiretypes/openai.wiretypes.ts
@@ -1593,10 +1593,18 @@ export namespace OpenAIWire_Responses_Tools {
   //   // OpenAI vector store feature - not implemented
   // });
 
-  // const MCPTool_schema = z.object({
-  //   type: z.literal('mcp'),
-  //   // MCP (Model Context Protocol) tools - not implemented yet
-  // });
+  // MCP tool - server-side execution of remote MCP servers/connectors
+  // OpenAI: 'remote MCP servers' (server_url or connector_id); AWS Bedrock Mantle: connector_id = Lambda or AgentCore Gateway ARN
+  const MCPTool_schema = z.object({
+    type: z.literal('mcp'),
+    server_label: z.string(), // unique identifier for this tool connector within the request
+    connector_id: z.string().optional(), // provider-specific connector (Bedrock: Lambda/AgentCore Gateway ARN; OpenAI: e.g. 'connector_dropbox')
+    server_url: z.string().optional(), // OpenAI-only alternative: URL of a remote MCP server
+    server_description: z.string().optional(), // human-readable description of the tools provided
+    require_approval: z.enum(['never', 'always']).or(z.any()).optional(), // Bedrock requires the literal 'never'; OpenAI also accepts a granular object
+    allowed_tools: z.array(z.string()).optional(), // optional tool filter
+    headers: z.record(z.string(), z.string()).optional(), // OpenAI-only: auth headers for server_url MCP servers
+  });
 
   // Combined tools
 
@@ -1609,8 +1617,8 @@ export namespace OpenAIWire_Responses_Tools {
     WebSearchTool_schema,
     ImageGenerationTool_schema,
     CodeInterpreterTool_schema,
+    MCPTool_schema, // server-side remote MCP servers/connectors (OpenAI, Bedrock Mantle)
     // FileSearchTool_schema, // OpenAI vector store - not implemented
-    // MCPTool_schema,
     // ComputerUseTool_schema,
     // LocalShellTool_schema,
   ]);

--- a/src/modules/llms/models-modal/LLMParametersEditor.tsx
+++ b/src/modules/llms/models-modal/LLMParametersEditor.tsx
@@ -153,6 +153,11 @@ const _antWebSearchOptions = [
   { value: _UNSPECIFIED, label: 'Off', description: 'Disabled (default)' },
 ] as const;
 
+const _bedrockWebSearchOptions = [
+  { value: 'auto', label: 'On', description: 'AWS-native web search, executed server-side by Bedrock' },
+  { value: _UNSPECIFIED, label: 'Off', description: 'Disabled (default)' },
+] as const;
+
 const _antWebFetchOptions = [
   { value: 'auto', label: 'On', description: 'Enable fetching web content and PDFs' },
   { value: _UNSPECIFIED, label: 'Off', description: 'Disabled (default)' },
@@ -270,6 +275,7 @@ export function LLMParametersEditor(props: {
     llmVndAntWebFetchMaxUses,
     llmVndAntWebSearch,
     llmVndAntWebSearchMaxUses,
+    llmVndBedrockWebSearch,
     llmVndGemEffort,
     llmVndGeminiAgentViz,
     llmVndGeminiAspectRatio,
@@ -497,6 +503,20 @@ export function LLMParametersEditor(props: {
       />
     )}
 
+
+    {/* Bedrock: server-side Web Search via the deployment's AgentCore Gateway */}
+    {showParam('llmVndBedrockWebSearch') && (
+      <FormSelectControl
+        title='Web Search'
+        tooltip='AWS-native web search over an Amazon-operated index, executed server-side by Bedrock via the AgentCore Gateway configured on this deployment'
+        value={llmVndBedrockWebSearch ?? _UNSPECIFIED}
+        onChange={(value) => {
+          if (value === _UNSPECIFIED || !value) onRemoveParameter('llmVndBedrockWebSearch');
+          else onChangeParameter({ llmVndBedrockWebSearch: value });
+        }}
+        options={_bedrockWebSearchOptions}
+      />
+    )}
 
     {showParam('llmVndAntWebSearch') && (
       <FormSelectControl

--- a/src/modules/llms/server/bedrock/bedrock.models.ts
+++ b/src/modules/llms/server/bedrock/bedrock.models.ts
@@ -34,6 +34,7 @@ import type { ModelDescriptionSchema } from '../llm.server.types';
 import { llmsAntInjectVariants, llmBedrockFindAnthropicModel, llmBedrockStripAnthropicMDS } from '../anthropic/anthropic.models';
 import { LLM_IF_ANT_PromptCaching, LLM_IF_HOTFIX_NoTemperature, LLM_IF_OAI_Chat, LLM_IF_OAI_Fn, LLM_IF_OAI_Reasoning, LLM_IF_OAI_Vision, LLM_IF_Outputs_Audio, LLM_IF_Outputs_Image } from '~/common/stores/llms/llms.types';
 import { DModelParameterSpecAny } from '~/common/stores/llms/llms.parameters';
+import { env } from '~/server/env.server';
 
 
 // --- Suppression Rules ---
@@ -315,6 +316,9 @@ export function bedrockModelsToDescriptions(
   const bedrockAPIConverse = { paramId: 'llmVndBedrockAPI', initialValue: 'converse' } as const satisfies DModelParameterSpecAny;
   const bedrockAPIMantle = { paramId: 'llmVndBedrockAPI', initialValue: 'mantle' } as const satisfies DModelParameterSpecAny;
   const bedrockAPIMantleResponses = { paramId: 'llmVndBedrockAPI', initialValue: 'mantle-responses' } as const satisfies DModelParameterSpecAny;
+  // Web Search toggle: only offered when the deployment configured an AgentCore Gateway for server-side MCP tools
+  const bedrockWebSearch = { paramId: 'llmVndBedrockWebSearch' } as const satisfies DModelParameterSpecAny;
+  const hasBedrockWebSearch = !!env.BEDROCK_AGENTCORE_GATEWAY_ARN;
   for (const [modelId, modelMeta] of modelMap) {
     if (_seemsAnthropicBedrockModel(modelId)) {
 
@@ -401,7 +405,7 @@ export function bedrockModelsToDescriptions(
       contextWindow: known?.ctx ?? 131072,
       maxCompletionTokens: known?.out ?? 16384,
       interfaces,
-      parameterSpecs: [isResponsesOnly ? bedrockAPIMantleResponses : bedrockAPIMantle],
+      parameterSpecs: [isResponsesOnly ? bedrockAPIMantleResponses : bedrockAPIMantle, ...(isResponsesOnly && hasBedrockWebSearch ? [bedrockWebSearch] : [])],
       hidden: !isResponsesOnly, // show models with a curated API assignment; hide the rest (listed by Mantle, but unverified: some ids 400 with "isn't supported on this route", others are account-gated)
     });
   }

--- a/src/modules/llms/server/llm.server.types.ts
+++ b/src/modules/llms/server/llm.server.types.ts
@@ -94,6 +94,7 @@ const ModelParameterSpec_schema = z.object({
     'llmVndAntWebSearchMaxUses',
     // Bedrock
     'llmVndBedrockAPI',
+    'llmVndBedrockWebSearch',
     // Gemini
     'llmVndGeminiAgentViz',
     'llmVndGeminiAspectRatio',

--- a/src/server/env.server.ts
+++ b/src/server/env.server.ts
@@ -59,6 +59,7 @@ export const env = createEnv({
     BEDROCK_SECRET_ACCESS_KEY: z.string().optional(),
     BEDROCK_SESSION_TOKEN: z.string().optional(), // required with the other 2 on corporate accounts sometimes
     BEDROCK_REGION: z.string().optional(),
+    BEDROCK_AGENTCORE_GATEWAY_ARN: z.string().optional(), // AgentCore Gateway ARN for server-side MCP tools (e.g. the managed Web Search connector) - adds a per-model Web Search toggle to Responses-capable Mantle models
 
     // LLM: Cerebras
     CEREBRAS_API_KEY: z.string().optional(),


### PR DESCRIPTION
## What

Opt-in, per-model **Web Search** for AWS Bedrock Mantle models on the Responses API, executed entirely server-side by Bedrock via its server-side MCP tools: the request carries a `{type: "mcp", connector_id: <AgentCore Gateway ARN>, require_approval: "never"}` tools entry, and Bedrock drives the tool loop against the gateway. With AWS's managed [Web Search Tool connector](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-target-connector-web-search-tool.html) on the gateway, models get web search over an Amazon-operated index — no third-party search API keys, and queries never leave AWS (relevant for data-egress-sensitive deployments).

## How

- **`BEDROCK_AGENTCORE_GATEWAY_ARN`** server env var (documented). Fully dormant when unset: the parameter is never offered, and a stray flag is ignored at dispatch.
- **`llmVndBedrockWebSearch`** (`'auto'`) model parameter, following the existing hosted web-search pattern (Anthropic `llmVndAntWebSearch`, OpenAI `llmVndOaiWebSearchContext`). The model listing attaches it only to Responses-capable Mantle models and only when the gateway ARN is configured — unconfigured deployments never see the toggle.
- **Dispatch**: the `mantle-responses` case appends the `mcp` tools entry when both the per-model flag and the env var are present. `require_approval: "never"` as Bedrock mandates.
- **Wiretypes**: `MCPTool_schema` request tool (completing the existing stub), covering both OpenAI remote-MCP fields (`server_url`, `headers`) and connector fields (`connector_id`).
- **IAM**: the identity calling Bedrock needs `bedrock-agentcore:InvokeGateway` on the gateway. Composes with static credentials and with ECS task-role (ambient) auth.

## Depends on

- The Bedrock `mantle-responses` API variant PR (this feature is for models on that path).
- The Responses-MCP parser PR (renders the tool activity).

## Tested

Live on us-east-1 with a gateway carrying the managed `web-search` connector:

- GPT-5.6 Terra, streaming: `Calling WebSearch...` placeholder → `WebSearch completed: <query>` (search-web affordance), answer with cited source URLs ✅
- Non-streaming: all completed tool calls surfaced, cited answer ✅
- Toggle off: no tools entry, normal chat ✅
- Env unset: parameter absent from the listing; requests carrying the flag anyway complete normally with no tool injection ✅
- `tsc --noEmit` clean, `next build` passes

## Notes

- The gateway is one-time deployment infrastructure (gateway + service role + `web-search` connector target); an example CLI setup is in the docs link above. The Web Search Tool itself has no additional charge per AWS (gateway data transfer only) and is currently us-east-1.
- AWS's acceptable-use terms require retaining/displaying source citations from search results — the model composes cited answers into its text, which big-AGI renders as-is.
