### PR TITLE
Chat: per-conversation model binding for multi-model Multi-Chat

### DIFF
--- a/src/apps/chat/AppChat.tsx
+++ b/src/apps/chat/AppChat.tsx
@@ -28,8 +28,7 @@ import { addSnackbar, removeSnackbar } from '~/common/components/snackbar/useSna
 import { createDMessageFromFragments, createDMessagePlaceholderIncomplete, DMessageMetadata, duplicateDMessageMetadata } from '~/common/stores/chat/chat.message';
 import { createErrorContentFragment, createTextContentFragment, DMessageAttachmentFragment, DMessageContentFragment, duplicateDMessageFragments } from '~/common/stores/chat/chat.fragments';
 import { gcChatImageAssets } from '~/common/stores/chat/chat.gc';
-import { getChatLLMId } from '~/common/stores/llms/store-llms';
-import { getConversation, getConversationSystemPurposeId, useConversation } from '~/common/stores/chat/store-chats';
+import { getConversation, getConversationChatLLMId, getConversationSystemPurposeId, useConversation } from '~/common/stores/chat/store-chats';
 import { optimaActions, optimaOpenModels, optimaOpenPreferences, useOptimaChromeless } from '~/common/layout/optima/useOptima';
 import { useFolderStore } from '~/common/stores/folders/store-chat-folders';
 import { useIsMobile, useIsTallScreen } from '~/common/components/useMatchMedia';
@@ -538,10 +537,10 @@ export function AppChat() {
   // Shortcuts
 
   const handleOpenChatLlmOptions = React.useCallback(() => {
-    const chatLLMId = getChatLLMId();
+    const chatLLMId = getConversationChatLLMId(focusedPaneConversationId);
     if (!chatLLMId) return;
     optimaActions().openModelOptions(chatLLMId);
-  }, []);
+  }, [focusedPaneConversationId]);
 
   const handleMoveFocus = React.useCallback((direction: number, wholeList?: boolean) => {
     // find the parent list

--- a/src/apps/chat/components/PaneTitleOverlay.tsx
+++ b/src/apps/chat/components/PaneTitleOverlay.tsx
@@ -9,6 +9,8 @@ import OpenInFullIcon from '@mui/icons-material/OpenInFull';
 import type { DConversationId } from '~/common/stores/chat/chat.conversation';
 import { InlineTextarea } from '~/common/components/InlineTextarea';
 import { TooltipOutlined } from '~/common/components/TooltipOutlined';
+import { getLLMLabel } from '~/common/stores/llms/llms.types';
+import { useConversationModelBinding } from '~/common/stores/chat/hooks/useConversationModelBinding';
 import { useConversationTitle } from '~/common/stores/chat/hooks/useConversationTitle';
 
 import { panesManagerActions } from './panes/store-panes-manager';
@@ -52,6 +54,34 @@ const _styles = {
     minWidth: '2.75rem',
     textAlign: 'center',
   } as const,
+  modelBadge: {
+    fontSize: 'xs',
+    fontWeight: 'md',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    maxWidth: '11rem',
+    px: 0.75,
+    borderRadius: 'sm',
+    cursor: 'default',
+    // following-default styling: dimmed, italic
+    fontStyle: 'italic',
+    opacity: 0.6,
+  } as const,
+  modelBadgePinned: {
+    fontSize: 'xs',
+    fontWeight: 'md',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    maxWidth: '11rem',
+    px: 0.75,
+    borderRadius: 'sm',
+    cursor: 'default',
+    // pinned styling: full-strength, outlined chip
+    border: '1px solid',
+    borderColor: 'currentColor',
+  } as const,
   toolButton: {
     '--IconButton-size': '1.5rem',
     backgroundColor: 'transparent',
@@ -81,6 +111,7 @@ export function PaneTitleOverlay(props: {
 
   // external state
   const { title, setUserTitle } = useConversationTitle(props.conversationId);
+  const { isPinned, boundLlm } = useConversationModelBinding(props.conversationId);
   // if (!title || title?.length < 3)
   //   return null;
 
@@ -172,6 +203,15 @@ export function PaneTitleOverlay(props: {
             <EditRoundedIcon sx={_styles.toolIcon} />
           </IconButton>
         </TooltipOutlined>}
+
+        {/* Per-pane model badge: which model this conversation runs on (pinned vs following the app default) */}
+        {!!boundLlm && (
+          <TooltipOutlined title={isPinned ? 'Model pinned to this chat' : 'Following the app default model'}>
+            <Box sx={isPinned ? _styles.modelBadgePinned : _styles.modelBadge}>
+              {isPinned ? '📌 ' : ''}{getLLMLabel(boundLlm)}
+            </Box>
+          </TooltipOutlined>
+        )}
       </>}
 
       {/* Delete This */}

--- a/src/apps/chat/components/layout-bar/ChatBarChat.tsx
+++ b/src/apps/chat/components/layout-bar/ChatBarChat.tsx
@@ -22,7 +22,7 @@ export function ChatBarChat(props: {
   // state
   const showNavigation = useChatShowToolbarNavigation();
   const { title } = useConversationTitle(props.conversationId);
-  const { chatLLMDropdown } = useChatLLMDropdown(props.llmDropdownRef);
+  const { chatLLMDropdown } = useChatLLMDropdown(props.llmDropdownRef, props.conversationId);
   const { personaDropdown } = usePersonaIdDropdown(props.conversationId, props.personaDropdownRef);
   const { folderDropdown } = useFolderDropdown(props.conversationId);
 

--- a/src/apps/chat/components/layout-bar/useLLMDropdown.tsx
+++ b/src/apps/chat/components/layout-bar/useLLMDropdown.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 import { Box, IconButton, ListItemButton, ListItemDecorator } from '@mui/joy';
 import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded';
 import BuildCircleIcon from '@mui/icons-material/BuildCircle';
+import PushPinIcon from '@mui/icons-material/PushPin';
+import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
 import SettingsIcon from '@mui/icons-material/Settings';
 
 import { findModelVendor } from '~/modules/llms/vendors/vendors.registry';
@@ -21,6 +23,10 @@ import { useAllLLMs } from '~/common/stores/llms/hooks/useAllLLMs';
 import { setPrimaryChatModelId, useModelDomain } from '~/common/stores/llms/hooks/useModelDomain';
 import { useUIComplexityMode } from '~/common/stores/store-ui';
 
+import type { DConversationId } from '~/common/stores/chat/chat.conversation';
+import { useChatStore } from '~/common/stores/chat/store-chats';
+import { useConversationModelBinding } from '~/common/stores/chat/hooks/useConversationModelBinding';
+
 
 function LLMDropdown(props: {
   dropdownRef: React.Ref<OptimaBarControlMethods>,
@@ -28,6 +34,8 @@ function LLMDropdown(props: {
   chatLlmId: undefined | DLLMId | null,
   setChatLlmId: (llmId: DLLMId) => void,
   placeholder?: string,
+  isPinned?: boolean, // the active model is pinned to the focused conversation
+  onTogglePin?: () => void, // pin the active model to the focused conversation / revert to following the app default
 }) {
 
   // state
@@ -38,7 +46,7 @@ function LLMDropdown(props: {
   const showSymbols = uiComplexityMode !== 'minimal';
 
   // derived state
-  const { chatLlmId, llms, setChatLlmId } = props;
+  const { chatLlmId, llms, setChatLlmId, isPinned, onTogglePin } = props;
 
   const llmsCount = llms.filter(isLLMVisible).length;
   const showFilter = llmsCount >= 50;
@@ -91,9 +99,10 @@ function LLMDropdown(props: {
         sepCount++;
       }
 
-      // add the model item
+      // add the model item - prefix the active item with a pin when bound to the focused conversation
+      const _isPinnedActive = isPinned && llm.id === chatLlmId;
       llmItems[llm.id] = {
-        title: getLLMLabel(llm),
+        title: (_isPinnedActive ? '📌 ' : '') + getLLMLabel(llm),
         ...(llm.userStarred ? { symbol: '⭐' } : {}),
         // icon: llm.id.startsWith('some vendor') ? <VendorIcon /> : undefined,
       };
@@ -115,7 +124,7 @@ function LLMDropdown(props: {
 
     // otherwise update the cache and return the new items
     return stabilizeLlmOptions.current = llmItems;
-  }, [chatLlmId, llms, filterString]);
+  }, [chatLlmId, isPinned, llms, filterString]);
 
 
   // "Model Options" button (only on the active item)
@@ -172,6 +181,16 @@ function LLMDropdown(props: {
   // "Models Setup" button
   const llmDropdownAppendOptions = React.useMemo(() => <>
 
+    {/* Pin to this chat / Follow default - per-conversation model binding */}
+    {!!onTogglePin && !!chatLlmId && (
+      <ListItemButton key='menu-pin' onClick={onTogglePin} sx={{ backgroundColor: 'background.surface', py: 'calc(2 * var(--ListDivider-gap))' }}>
+        <ListItemDecorator>{isPinned ? <PushPinIcon color='primary' /> : <PushPinOutlinedIcon />}</ListItemDecorator>
+        <Box sx={{ flexGrow: 1, display: 'flex', justifyContent: 'space-between', gap: 1, alignItems: 'center' }}>
+          {isPinned ? 'Unpin · follow app default' : 'Pin model to this chat'}
+        </Box>
+      </ListItemButton>
+    )}
+
     {/*{chatLlmId && (*/}
     {/*  <ListItemButton key='menu-opt' onClick={handleOpenLLMOptions}>*/}
     {/*    <ListItemDecorator><SettingsIcon color='success' /></ListItemDecorator>*/}
@@ -193,7 +212,7 @@ function LLMDropdown(props: {
       </Box>
     </ListItemButton>
 
-  </>, [hasDropdownOptions]);
+  </>, [chatLlmId, hasDropdownOptions, isPinned, onTogglePin]);
 
 
   return (
@@ -212,17 +231,39 @@ function LLMDropdown(props: {
 }
 
 
-export function useChatLLMDropdown(dropdownRef: React.Ref<OptimaBarControlMethods>) {
+export function useChatLLMDropdown(dropdownRef: React.Ref<OptimaBarControlMethods>, pinConversationId: DConversationId | null = null) {
 
   // external state
   const llms = useAllLLMs();
   const { domainModelId: chatLLMId } = useModelDomain('primaryChat');
+  const { isPinned, boundLlmId } = useConversationModelBinding(pinConversationId);
+
+  // Option A semantics: when the conversation is pinned, the selector edits the pin;
+  // otherwise it keeps writing the app-level 'primaryChat' default (unchanged behavior)
+  const activeLlmId = isPinned ? boundLlmId : chatLLMId;
+
+  const handleSetLlmId = React.useCallback((llmId: DLLMId) => {
+    if (isPinned && pinConversationId)
+      useChatStore.getState().setUserLlmId(pinConversationId, llmId);
+    else
+      setPrimaryChatModelId(llmId);
+  }, [isPinned, pinConversationId]);
+
+  const handleTogglePin = React.useCallback(() => {
+    if (!pinConversationId) return;
+    // pin the currently-active model, or revert to following the app default
+    useChatStore.getState().setUserLlmId(pinConversationId, isPinned ? null : (activeLlmId ?? null));
+  }, [activeLlmId, isPinned, pinConversationId]);
 
   const chatLLMDropdown = React.useMemo(() => {
-    return <LLMDropdown dropdownRef={dropdownRef} llms={llms} chatLlmId={chatLLMId} setChatLlmId={setPrimaryChatModelId} />;
-  }, [chatLLMId, dropdownRef, llms]);
+    return <LLMDropdown
+      dropdownRef={dropdownRef} llms={llms}
+      chatLlmId={activeLlmId} setChatLlmId={handleSetLlmId}
+      isPinned={isPinned} onTogglePin={pinConversationId ? handleTogglePin : undefined}
+    />;
+  }, [activeLlmId, dropdownRef, handleSetLlmId, handleTogglePin, isPinned, llms, pinConversationId]);
 
-  return { chatLLMId, chatLLMDropdown };
+  return { chatLLMId: activeLlmId, chatLLMDropdown };
 }
 
 /*export function useTempLLMDropdown(props: { initialLlmId: DLLMId | null }) {

--- a/src/apps/chat/editors/_handleExecute.ts
+++ b/src/apps/chat/editors/_handleExecute.ts
@@ -1,11 +1,11 @@
-import { getChatLLMId } from '~/common/stores/llms/store-llms';
+
 
 import type { DConversationId } from '~/common/stores/chat/chat.conversation';
 import type { DMessage } from '~/common/stores/chat/chat.message';
 import { ConversationHandler } from '~/common/chat-overlay/ConversationHandler';
 import { ConversationsManager } from '~/common/chat-overlay/ConversationsManager';
 import { createTextContentFragment, isContentOrAttachmentFragment, isImageRefPart, isTextContentFragment, isZyncAssetImageReferencePart } from '~/common/stores/chat/chat.fragments';
-import { getConversationSystemPurposeId } from '~/common/stores/chat/store-chats';
+import { getConversationChatLLMId, getConversationSystemPurposeId } from '~/common/stores/chat/store-chats';
 
 import type { ChatExecuteMode } from '../execute-mode/execute-mode.types';
 import { textToDrawCommand } from '../commands/CommandsDraw';
@@ -22,7 +22,7 @@ export async function _handleExecute(chatExecuteMode: ChatExecuteMode, conversat
   if (!conversationId)
     return 'err-no-conversation';
 
-  const chatLLMId = getChatLLMId();
+  const chatLLMId = getConversationChatLLMId(conversationId); // conversation-pinned model, or the 'primaryChat' domain default
   const cHandler = ConversationsManager.getHandler(conversationId);
   const initialHistory = cHandler.historyViewHeadOrThrow('handle-execute-' + executeCallerNameDebug) as Readonly<DMessage[]>;
 

--- a/src/common/chat-overlay/ConversationHandler.ts
+++ b/src/common/chat-overlay/ConversationHandler.ts
@@ -10,11 +10,10 @@ import { useModuleBeamStore } from '~/modules/beam/store-module-beam';
 
 import type { DConversationId } from '~/common/stores/chat/chat.conversation';
 import type { DLLMId } from '~/common/stores/llms/llms.types';
-import { ChatActions, getConversationSystemPurposeId, isValidConversation, useChatStore } from '~/common/stores/chat/store-chats';
+import { ChatActions, getConversationChatLLMId, getConversationSystemPurposeId, isValidConversation, useChatStore } from '~/common/stores/chat/store-chats';
 import { createDMessageEmpty, createDMessageFromFragments, createDMessagePlaceholderIncomplete, createDMessageTextContent, DMessage, DMessageGenerator, DMessageId, DMessageUserFlag, MESSAGE_FLAG_VND_ANT_CACHE_AUTO, MESSAGE_FLAG_VND_ANT_CACHE_USER, messageHasUserFlag, messageSetUserFlag } from '~/common/stores/chat/chat.message';
 import { createTextContentFragment, DMessageFragment, DMessageFragmentId } from '~/common/stores/chat/chat.fragments';
 import { gcChatImageAssets } from '~/common/stores/chat/chat.gc';
-import { getChatLLMId } from '~/common/stores/llms/store-llms';
 
 import { getChatAutoAI, getChatThinkingPolicy } from '../../apps/chat/store-app-chat';
 
@@ -282,8 +281,9 @@ export class ConversationHandler {
         void autoConversationTitle(this.conversationId, false);
     };
 
-    beamOpen(viewHistory, getChatLLMId(), !!destReplaceMessageId, onBeamSuccess);
-    importMessages.length && beamImportRays(importMessages, getChatLLMId());
+    const beamSeedLlmId = getConversationChatLLMId(this.conversationId); // conversation-pinned model, or the 'primaryChat' domain default
+    beamOpen(viewHistory, beamSeedLlmId, !!destReplaceMessageId, onBeamSuccess);
+    importMessages.length && beamImportRays(importMessages, beamSeedLlmId);
   }
 
 

--- a/src/common/stores/chat/chat.conversation.ts
+++ b/src/common/stores/chat/chat.conversation.ts
@@ -1,5 +1,6 @@
 import { defaultSystemPurposeId, SystemPurposeId } from '../../../data';
 
+import type { DLLMId } from '~/common/stores/llms/llms.types';
 import { agiUuid } from '~/common/util/idUtils';
 
 import { DMessage, DMessageId, duplicateDMessage } from './chat.message';
@@ -25,6 +26,8 @@ export interface DConversation {
   // TODO: [x Head] - this should be the system purpose of current head of the conversation
   // there should be the concept of the audience of the current head
   systemPurposeId: SystemPurposeId;   // system purpose of this conversation
+
+  userLlmId?: DLLMId;                 // optional: model pinned to this conversation - absent = follow the 'primaryChat' domain default; broken pins degrade to the default at resolution time
 
   // when updated is null, we don't have messages yet (timestamps as Date.now())
   created: number;                    // creation timestamp
@@ -98,6 +101,7 @@ export function duplicateDConversation(conversation: DConversation, lastMessageI
     ...(conversation.isArchived !== undefined ? { isArchived: conversation.isArchived } : {}), // copy archival state if set
 
     systemPurposeId: conversation.systemPurposeId,
+    ...(conversation.userLlmId ? { userLlmId: conversation.userLlmId } : {}), // carry the pinned model into the branch
     tokenCount: conversation.tokenCount,
 
     created: conversation.created,

--- a/src/common/stores/chat/chats.converters.ts
+++ b/src/common/stores/chat/chats.converters.ts
@@ -181,6 +181,8 @@ export namespace V3StoreDataToHead {
     if (created) cc.created = created;
     if (updated) cc.updated = updated;
     cc.tokenCount = ('tokenCount' in ic) ? ic.tokenCount || 0 : cc.tokenCount || 0;
+    // round-trip the conversation-pinned model, when set (V4+ exports; broken pins degrade at resolution time)
+    if ('userLlmId' in ic && typeof ic.userLlmId === 'string' && ic.userLlmId) cc.userLlmId = ic.userLlmId;
 
     return cc;
   }
@@ -352,6 +354,7 @@ export namespace DataAtRestV1 {
     id: string;
     messages: (DMessage | V3StoreDataToHead.ImportMessageV3)[];
     systemPurposeId: string;
+    userLlmId?: string; // optional conversation-pinned model - broken pins degrade at resolution time
     userTitle?: string;
     autoTitle?: string;
     created: number;

--- a/src/common/stores/chat/hooks/useConversationModelBinding.ts
+++ b/src/common/stores/chat/hooks/useConversationModelBinding.ts
@@ -1,0 +1,31 @@
+import type { DLLM, DLLMId } from '~/common/stores/llms/llms.types';
+import { useLLM } from '~/common/stores/llms/llms.hooks';
+import { useModelDomain } from '~/common/stores/llms/hooks/useModelDomain';
+
+import type { DConversationId } from '../chat.conversation';
+import { useChatStore } from '../store-chats';
+
+
+/**
+ * Per-conversation model binding: the pinned model (conversation.userLlmId) when set and still
+ * existing, otherwise the 'primaryChat' domain default. Mirrors getConversationChatLLMId, but
+ * reactive for the UI (model selector pin state, pane badges).
+ */
+export function useConversationModelBinding(conversationId: DConversationId | null): {
+  isPinned: boolean;
+  boundLlmId: DLLMId | null;
+  boundLlm: DLLM | undefined;
+} {
+
+  // external state
+  const userLlmId = useChatStore(state => !conversationId ? undefined : state.conversations.find(_c => _c.id === conversationId)?.userLlmId);
+  const { domainModelId } = useModelDomain('primaryChat');
+  const pinnedLlm = useLLM(userLlmId); // undefined when the pin is broken (model removed / different install) - degrade to the default
+
+  // derived state
+  const isPinned = !!userLlmId && !!pinnedLlm;
+  const boundLlmId: DLLMId | null = isPinned ? userLlmId : (domainModelId ?? null);
+  const boundLlm = useLLM(boundLlmId);
+
+  return { isPinned, boundLlmId, boundLlm };
+}

--- a/src/common/stores/chat/store-chats.test.ts
+++ b/src/common/stores/chat/store-chats.test.ts
@@ -1,0 +1,108 @@
+/// <reference types="node" />
+
+// Unit tests for per-conversation model binding: getConversationChatLLMId's resolution order
+// (chat pin > 'primaryChat' domain default) and silent degradation of a broken pin.
+//
+// Runs entirely against the real Zustand stores (useChatStore, useModelsStore) - no mocks -
+// per this repo's test philosophy: assert real behavior, not a stubbed string.
+//
+// Run: `npm test` or `NODE_ENV=development npx tsx --test src/common/stores/chat/store-chats.test.ts`
+
+import { describe, test } from 'node:test';
+import { deepStrictEqual as eq, ok } from 'node:assert';
+
+import { createDConversation } from './chat.conversation';
+import { getConversationChatLLMId, useChatStore } from './store-chats';
+import { useModelsStore } from '~/common/stores/llms/store-llms';
+import type { DLLM } from '~/common/stores/llms/llms.types';
+
+
+function _fakeLLM(id: string): DLLM {
+  return {
+    id,
+    label: id,
+    created: 0,
+    updated: 0,
+    description: '',
+    tags: [],
+    contextWindow: 8192,
+    maxCompletionTokens: null,
+    trainingDataCutoff: undefined,
+    interfaces: [],
+    parameterSpecs: [],
+    benchmark: undefined,
+    pricing: undefined,
+    isLegacy: false,
+    hidden: false,
+    sId: 'test-service',
+    vId: 'openai',
+  } as unknown as DLLM;
+}
+
+/** Install two fake LLMs and pin 'llm-default' as the 'primaryChat' domain assignment. */
+function _seedLlmUniverse() {
+  useModelsStore.setState({
+    llms: [_fakeLLM('llm-default'), _fakeLLM('llm-pinned')],
+    modelAssignments: { primaryChat: { domainId: 'primaryChat', modelId: 'llm-default' } },
+  } as any);
+}
+
+function _addConversation(userLlmId?: string) {
+  const c = createDConversation();
+  if (userLlmId) c.userLlmId = userLlmId;
+  useChatStore.setState(state => ({ conversations: [c, ...state.conversations] }));
+  return c.id;
+}
+
+
+describe('getConversationChatLLMId - per-conversation model binding', () => {
+
+  test('unpinned conversation resolves to the primaryChat domain default', () => {
+    _seedLlmUniverse();
+    const conversationId = _addConversation(/* no pin */);
+
+    eq(getConversationChatLLMId(conversationId), 'llm-default');
+  });
+
+  test('pinned conversation resolves to the pin, not the domain default', () => {
+    _seedLlmUniverse();
+    const conversationId = _addConversation('llm-pinned');
+
+    eq(getConversationChatLLMId(conversationId), 'llm-pinned');
+  });
+
+  test('broken pin (model no longer exists) silently degrades to the domain default', () => {
+    _seedLlmUniverse();
+    const conversationId = _addConversation('llm-deleted-service');
+
+    // never throws, never surfaces the broken id - falls back exactly like a broken domain assignment
+    eq(getConversationChatLLMId(conversationId), 'llm-default');
+  });
+
+  test('null conversationId resolves to the domain default (no conversation context)', () => {
+    _seedLlmUniverse();
+
+    eq(getConversationChatLLMId(null), 'llm-default');
+  });
+
+  test('unknown conversationId resolves to the domain default (defensive)', () => {
+    _seedLlmUniverse();
+
+    eq(getConversationChatLLMId('does-not-exist'), 'llm-default');
+  });
+
+  test('setUserLlmId(id) pins, and setUserLlmId(null) reverts to following the default', () => {
+    _seedLlmUniverse();
+    const conversationId = _addConversation(/* no pin */);
+    eq(getConversationChatLLMId(conversationId), 'llm-default');
+
+    useChatStore.getState().setUserLlmId(conversationId, 'llm-pinned');
+    eq(getConversationChatLLMId(conversationId), 'llm-pinned');
+    ok(!!useChatStore.getState().conversations.find(c => c.id === conversationId)?.userLlmId, 'pin is persisted on the conversation');
+
+    useChatStore.getState().setUserLlmId(conversationId, null);
+    eq(getConversationChatLLMId(conversationId), 'llm-default');
+    ok(!useChatStore.getState().conversations.find(c => c.id === conversationId)?.userLlmId, 'unpin clears the field entirely (undefined, not null/empty string)');
+  });
+
+});

--- a/src/common/stores/chat/store-chats.ts
+++ b/src/common/stores/chat/store-chats.ts
@@ -51,6 +51,7 @@ export interface ChatActions {
   replaceMessageFragment: (cId: DConversationId, mId: DMessageId, fId: DMessageFragmentId, newFragment: DMessageFragment, removePendingState: boolean, touchUpdated: boolean) => void;
   updateMetadata: (cId: DConversationId, mId: DMessageId, metadataDelta: Partial<DMessageMetadata>, touchUpdated?: boolean) => void;
   setSystemPurposeId: (cId: DConversationId, personaId: SystemPurposeId) => void;
+  setUserLlmId: (cId: DConversationId, userLlmId: DLLMId | null) => void;
   setAutoTitle: (cId: DConversationId, autoTitle: string) => void;
   setUserTitle: (cId: DConversationId, userTitle: string) => void;
   setUserSymbol: (cId: DConversationId, userSymbol: string | null) => void;
@@ -414,6 +415,11 @@ export const useChatStore = create<ConversationsStore>()(/*devtools(*/
           {
             systemPurposeId: personaId,
           }),
+      setUserLlmId: (conversationId: DConversationId, userLlmId: DLLMId | null) =>
+        _get()._editConversation(conversationId,
+          {
+            userLlmId: userLlmId || undefined, // null/'' = unpin, follow the domain default
+          }),
 
       setAutoTitle: (conversationId: DConversationId, autoTitle: string) =>
         _get()._editConversation(conversationId,
@@ -596,6 +602,25 @@ export function getConversation(conversationId: DConversationId | null): DConver
 
 export function getConversationSystemPurposeId(conversationId: DConversationId | null): SystemPurposeId | null {
   return getConversation(conversationId)?.systemPurposeId || null;
+}
+
+/**
+ * Resolve the chat model for a conversation: the pinned model (userLlmId) when set AND still
+ * existing, otherwise the 'primaryChat' domain default. Broken pins (model removed, or chat
+ * imported from an install with different services) silently degrade to the default - same
+ * semantics as broken domain assignments in llmsResolveDomainModel.
+ */
+export function getConversationChatLLMId(conversationId: DConversationId | null): DLLMId | null {
+  const userLlmId = getConversation(conversationId)?.userLlmId;
+  if (userLlmId) {
+    try {
+      findLLMOrThrow(userLlmId);
+      return userLlmId;
+    } catch {
+      // broken pin: fall through to the domain default
+    }
+  }
+  return getChatLLMId();
 }
 
 

--- a/src/common/stores/chat/store-chats.ts
+++ b/src/common/stores/chat/store-chats.ts
@@ -108,7 +108,7 @@ export const useChatStore = create<ConversationsStore>()(/*devtools(*/
         // caution, we sanitize and re-run this here, to upgrade the message to the current version
         V4ToHeadConverters.inMemHeadCleanDConversations([conversation]);
 
-        conversation.tokenCount = updateMessagesTokenCounts(conversation.messages, true, 'importConversation');
+        conversation.tokenCount = updateMessagesTokenCounts(conversation.id, conversation.messages, true, 'importConversation');
 
         _set({
           conversations: [conversation, ...conversations.filter(_c => _c.id !== conversation.id)],
@@ -220,7 +220,7 @@ export const useChatStore = create<ConversationsStore>()(/*devtools(*/
             ...(!!newMessages.length ? {} : {
               autoTitle: undefined,
             }),
-            tokenCount: updateMessagesTokenCounts(newMessages, false, 'historyReplace'),
+            tokenCount: updateMessagesTokenCounts(conversationId, newMessages, false, 'historyReplace'),
             updated: Date.now(),
             _abortController: null,
           };
@@ -241,7 +241,7 @@ export const useChatStore = create<ConversationsStore>()(/*devtools(*/
 
           return {
             messages: truncatedMessages,
-            tokenCount: updateMessagesTokenCounts(truncatedMessages, false, 'historyTruncateToIncluded'),
+            tokenCount: updateMessagesTokenCounts(conversationId, truncatedMessages, false, 'historyTruncateToIncluded'),
             updated: Date.now(),
             _abortController: null,
           };
@@ -295,7 +295,7 @@ export const useChatStore = create<ConversationsStore>()(/*devtools(*/
           workspaceActions().importAssignmentsFromMessages(workspaceForConversationIdentity(conversationId), [message]);
 
           if (!message.pendingIncomplete)
-            updateMessagesTokenCounts([message], true, 'appendMessage');
+            updateMessagesTokenCounts(conversationId, [message], true, 'appendMessage');
 
           const messages = [...conversation.messages, message];
 
@@ -338,7 +338,7 @@ export const useChatStore = create<ConversationsStore>()(/*devtools(*/
               delete updatedMessage.pendingIncomplete;
 
             if (!updatedMessage.pendingIncomplete)
-              updateMessageTokenCount(updatedMessage, getChatLLMId(), true, 'editMessage(incomplete=false)');
+              updateMessageTokenCount(updatedMessage, getConversationChatLLMId(conversationId), true, 'editMessage(incomplete=false)');
 
             return updatedMessage;
           });
@@ -546,14 +546,14 @@ export const useChatStore = create<ConversationsStore>()(/*devtools(*/
 );
 
 
-// Convenience function to update a set of messages, using the current chatLLM
-function updateMessagesTokenCounts(messages: DMessage[], forceUpdate: boolean, debugFrom: string): number {
+// Convenience function to update a set of messages, using the conversation-bound chatLLM (pin, or the 'primaryChat' domain default)
+function updateMessagesTokenCounts(conversationId: DConversationId | null, messages: DMessage[], forceUpdate: boolean, debugFrom: string): number {
 
   // no messages: 0, not the base overhead (0 = not yet calculated; keeps empty chats free of a phantom count)
   if (!messages.length)
     return 0;
 
-  const chatLLMId = getChatLLMId();
+  const chatLLMId = getConversationChatLLMId(conversationId);
   return 3 + messages.reduce((sum, message) => {
     return 4 + updateMessageTokenCount(message, chatLLMId, forceUpdate, debugFrom) + sum;
   }, 0);


### PR DESCRIPTION
Implements the design proposed in #1173 — see that issue for the full rationale, UX mock, and discussion of the pane-binding alternative. Opening as a draft so the design conversation in the issue can proceed independently of code review; happy to adjust (field name, UX details, or switch to pane-binding) based on how that discussion goes.

## Summary

- `DConversation.userLlmId?: DLLMId` — optional pinned model, resolved at execution time as `pin ?? primaryChat domain default`.
- `getConversationChatLLMId(conversationId)`: validated pin or default; broken pins (model removed, or chat imported from an install with different services) silently degrade to the default, mirroring `llmsResolveDomainModel`'s broken-assignment semantics.
- `_handleExecute` reads it instead of `getChatLLMId()` — one swap covers send, regenerate, retry, ReAct, and Multi-Chat broadcast (which already dispatches per conversation, so per-pane models fall out with no changes to the broadcast code itself). Beam's seed (`beamOpen`/`beamImportRays`) resolves per-conversation too.
- Utility flows (autotitle, fastUtil, codeApply, imageCaption) are untouched — they use the separate domain accessors.
- UX: model selector gains a "Pin model to this chat" / "Unpin · follow app default" entry; selecting a model edits the pin when pinned, the app default otherwise (zero behavior change until you pin). Each pane's title overlay now shows its bound model — outlined chip + 📌 when pinned, dimmed italic when following the default — so non-focused panes' models stay visible for side-by-side comparison.
- Persistence: optional field, no store version bump; `duplicateDConversation` copies the pin so branches keep their model; export carries it and import round-trips it (`chats.converters`).

## Tested

- Single-pane, no pin: byte-identical behavior to before (verified via the send/regenerate/ReAct paths reading the same resolved model as `getChatLLMId()` would return).
- Pin / unpin / re-pin via the selector menu; broken-pin degradation (delete the pinned service, confirm fallback to default).
- Duplicate/branch carries the pin; export → import round-trip.
- 4-pane broadcast with four different models across all Bedrock dispatch paths (Converse, Invoke-Anthropic, Mantle Chat Completions, Mantle Responses) — verified each pane continues multi-turn on its own model and the per-model tool state (e.g. a Responses-only model's Web Search toggle) stays scoped to its own pane.
- `tsc --noEmit`, `eslint`, and `next build` all clean.
