### PR TITLE
ReAct: include recent chat history in the agent context

### DIFF
--- a/src/apps/chat/editors/react-tangent.ts
+++ b/src/apps/chat/editors/react-tangent.ts
@@ -3,10 +3,38 @@ import { useBrowseStore } from '~/modules/browse/store-module-browsing';
 
 import type { ConversationHandler } from '~/common/chat-overlay/ConversationHandler';
 import type { DLLMId } from '~/common/stores/llms/llms.types';
-import { createErrorContentFragment, createTextContentFragment } from '~/common/stores/chat/chat.fragments';
+import type { DMessage } from '~/common/stores/chat/chat.message';
+import { createErrorContentFragment, createTextContentFragment, isTextContentFragment } from '~/common/stores/chat/chat.fragments';
 
 // configuration
 const EPHEMERAL_DELETION_DELAY = 5 * 1000;
+
+// ReAct chat-history context
+const REACT_HISTORY_TURNS = 6;   // last N user/assistant messages
+const REACT_HISTORY_CHARS = 600; // per-message cap
+
+/**
+ * Builds a compact transcript of the recent conversation so /react can
+ * resolve follow-ups ("what about the second one?"). Addresses the upstream
+ * `TODO: to initialize with previous chat messages to provide context` in react.ts.
+ */
+function buildHistoryContext(cHandler: ConversationHandler): string {
+  let messages: Readonly<DMessage[]>;
+  try {
+    messages = cHandler.historyViewHeadOrThrow('react-context');
+  } catch {
+    return '';
+  }
+  const lines: string[] = [];
+  for (const m of messages) {
+    if (m.role !== 'user' && m.role !== 'assistant') continue;
+    const text = m.fragments.filter(isTextContentFragment).map(f => f.part.text).join('\n').trim();
+    if (!text || text === '...') continue; // skip the assistant placeholder just appended
+    if (m.role === 'user' && text.startsWith('/react')) continue; // the current question arrives separately
+    lines.push(`${m.role === 'user' ? 'User' : 'Assistant'}: ${text.slice(0, REACT_HISTORY_CHARS)}`);
+  }
+  return lines.slice(-REACT_HISTORY_TURNS).join('\n');
+}
 
 
 /**
@@ -43,8 +71,14 @@ export async function runReActUpdatingState(cHandler: ConversationHandler, quest
   try {
 
     // react loop
+    // prepend the recent conversation so follow-up questions resolve
+    const historyContext = buildHistoryContext(cHandler);
+    const contextualQuestion = historyContext
+      ? `For context, here is the recent conversation:\n\n${historyContext}\n\nQuestion (if it references earlier topics, use the context above to interpret it): ${question}`
+      : question;
+
     const agent = new Agent(contextRef, abortController.signal);
-    const reactResult = await agent.reAct(question, assistantLlmId, 5, enableBrowse, logToEphemeral, showStateInEphemeral);
+    const reactResult = await agent.reAct(contextualQuestion, assistantLlmId, 5, enableBrowse, logToEphemeral, showStateInEphemeral);
 
     cHandler.messageFragmentReplace(assistantMessageId, placeholderFragmentId, createTextContentFragment(reactResult), true);
 


### PR DESCRIPTION
## Summary

Implements the long-standing TODO in `react.ts` (`to initialize with previous chat messages to provide context`): the ReAct agent now receives a compact transcript of the recent conversation, so follow-up questions like "what about the second one?" resolve against the actual chat subject instead of failing or hallucinating.

## How

- `react-tangent.ts` builds a transcript from the last 6 user/assistant messages (600 chars each), skipping the `/react` command message itself and the freshly appended assistant placeholder.
- The transcript is prepended as quoted context inside the question rather than injected as role messages into the loop's buffer, so the `Action:` regex parser can't trip on content from earlier turns.
- No history (first message of a conversation) → byte-identical behavior to today.

## Testing

- `tsc --noEmit` clean on current `main`.
- Manual: two-turn chat, then `/react` follow-up with a deictic reference → the agent searches for the right subject and answers.