### PR TITLE
Browse + Search: Jina AI backends (Reader r.jina.ai / Search s.jina.ai)

### DIFF
--- a/src/modules/backend/backend.router.ts
+++ b/src/modules/backend/backend.router.ts
@@ -68,8 +68,8 @@ export const backendRouter = createTRPCRouter({
         hasLlmXAI: !!env.XAI_API_KEY,
         // others
         hasDB: (!!env.MDB_URI) || (!!env.POSTGRES_PRISMA_URL && !!env.POSTGRES_URL_NON_POOLING),
-        hasBrowsing: !!env.PUPPETEER_WSS_ENDPOINT,
-        hasGoogleCustomSearch: !!env.GOOGLE_CSE_ID && !!env.GOOGLE_CLOUD_API_KEY,
+        hasBrowsing: !!env.PUPPETEER_WSS_ENDPOINT || !!env.JINA_API_KEY,
+        hasGoogleCustomSearch: (!!env.GOOGLE_CSE_ID && !!env.GOOGLE_CLOUD_API_KEY) || !!env.JINA_API_KEY,
         hasVoiceElevenLabs: !!env.ELEVENLABS_API_KEY,
         // hashes - TODO(2026-11): remove hashLlmReconfig + generateLlmEnvConfigHash: unread since LLM-Defs (per-vendor defsV), kept for pre-LLM-Defs clients
         hashLlmReconfig: generateLlmEnvConfigHash(env),

--- a/src/modules/browse/BrowseSettings.tsx
+++ b/src/modules/browse/BrowseSettings.tsx
@@ -5,9 +5,12 @@ import { Checkbox, FormControl, FormHelperText, FormLabel, Option, Select, Typog
 
 import { AlreadySet } from '~/common/components/AlreadySet';
 import { ExternalDocsLink } from '~/common/components/ExternalDocsLink';
+import { ExternalLink } from '~/common/components/ExternalLink';
 import { FormInputKey } from '~/common/components/forms/FormInputKey';
 import { FormLabelStart } from '~/common/components/forms/FormLabelStart';
 import { platformAwareKeystrokes } from '~/common/components/KeyStroke';
+
+import { isValidJinaApiKey, useJinaStore } from '~/modules/jina/store-module-jina';
 
 import { useBrowseCapability, useBrowseStore } from './store-module-browsing';
 
@@ -34,6 +37,12 @@ export function BrowseSettings() {
     setEnableReactTool: state.setEnableReactTool,
     setEnablePersonaTool: state.setEnablePersonaTool,
   })));
+  const { jinaApiKey, setJinaApiKey } = useJinaStore(useShallow(state => ({
+    jinaApiKey: state.jinaApiKey,
+    setJinaApiKey: state.setJinaApiKey,
+  })));
+
+  const isJinaValid = isValidJinaApiKey(jinaApiKey);
 
   const handlePageTransformChange = (_event: any, value: typeof pageTransform | null) => value && setPageTransform(value);
 
@@ -44,11 +53,22 @@ export function BrowseSettings() {
       Download and process web pages for analysis. <ExternalDocsLink docPage='self-host-optional-services'>Learn more</ExternalDocsLink>.
     </Typography>
 
+    {/* Jina Reader: browser-free page loading - used when the WSS endpoint below is empty */}
+    <FormInputKey
+      autoCompleteId='jina-key' label='Jina API Key'
+      description={<>No browser needed - uses <ExternalLink href='https://jina.ai/reader'>Jina Reader</ExternalLink> (works without a key at low rate limits)</>}
+      value={jinaApiKey} onChange={setJinaApiKey}
+      rightLabel={<AlreadySet required={!isServerConfig && !wssEndpoint} />}
+      required={false} isError={!!jinaApiKey && !isJinaValid}
+      placeholder='jina_...'
+    />
+
     <FormInputKey
       autoCompleteId='browse-wss' label='Puppeteer Wss' noKey
+      description='Optional - full browser; takes priority over Jina when set'
       value={wssEndpoint} onChange={setWssEndpoint}
-      rightLabel={<AlreadySet required={!isServerConfig} />}
-      required={!isServerConfig} isError={!isClientValid && !isServerConfig}
+      rightLabel={<AlreadySet required={!isServerConfig && !isJinaValid} />}
+      required={!isServerConfig && !isJinaValid} isError={!isClientValid && !isServerConfig}
       placeholder='wss://...'
     />
 

--- a/src/modules/browse/browse.client.ts
+++ b/src/modules/browse/browse.client.ts
@@ -1,4 +1,5 @@
 import { BrowsePageTransform, useBrowseStore } from '~/modules/browse/store-module-browsing';
+import { useJinaStore } from '~/modules/jina/store-module-jina';
 
 import { apiStreamNode } from '~/common/util/trpc.client';
 
@@ -26,12 +27,20 @@ export async function callBrowseFetchPageOrThrow(
     url = 'https://' + url;
 
   const { wssEndpoint, pageTransform } = useBrowseStore.getState();
+  const { jinaApiKey } = useJinaStore.getState();
+
+  // prefer the Puppeteer browser when configured; otherwise use the Jina Reader backend
+  // (also used when the server has JINA_API_KEY set - the router falls back to env)
+  const useJina = !wssEndpoint?.trim();
 
   // Connect to our service
   let streamingResponse: Awaited<ReturnType<typeof apiStreamNode.browse.fetchPagesStreaming.mutate>>;
   try {
     streamingResponse = await apiStreamNode.browse.fetchPagesStreaming.mutate({
-      access: {
+      access: useJina ? {
+        dialect: 'browse-jina',
+        ...(!!jinaApiKey?.trim() && { jinaApiKey: jinaApiKey.trim() }),
+      } : {
         dialect: 'browse-wss',
         ...(!!wssEndpoint && { wssEndpoint }),
       },

--- a/src/modules/browse/browse.router.ts
+++ b/src/modules/browse/browse.router.ts
@@ -25,8 +25,9 @@ type PageTransformSchema = z.infer<typeof pageTransformSchema>;
 
 const fetchPageInputSchema = z.object({
   access: z.object({
-    dialect: z.enum(['browse-wss']),
+    dialect: z.enum(['browse-wss', 'browse-jina']),
     wssEndpoint: z.string().trim().optional(),
+    jinaApiKey: z.string().trim().optional(),
   }),
   requests: z.array(z.object({
     url: z.url(),
@@ -73,6 +74,36 @@ export const browseRouter = createTRPCRouter({
   fetchPagesStreaming: publicProcedure
     .input(fetchPageInputSchema)
     .mutation(async function* ({ input: { access, requests } }) {
+
+      // Jina Reader dialect: plain HTTP fetch via r.jina.ai, no browser required
+      if (access.dialect === 'browse-jina') {
+        const jinaApiKey = (access.jinaApiKey || env.JINA_API_KEY || '').trim();
+        // NOTE: r.jina.ai also works keyless at a low rate limit, so an empty key is allowed
+
+        yield { type: 'ack-start' as const };
+
+        const results = await Promise.allSettled(requests.map(request =>
+          workerJina(request.url, request.transforms, jinaApiKey),
+        ));
+
+        const pages: FetchPageWorkerOutputSchema[] = results.map((result, index) =>
+          result.status === 'fulfilled' ? result.value : {
+            url: requests[index].url,
+            title: '',
+            content: undefined,
+            file: undefined,
+            error: result.reason instanceof Error ? result.reason.message : String(result.reason || 'Unknown fetch error'),
+            stopReason: 'error' as const,
+            screenshot: undefined,
+          });
+
+        yield {
+          type: 'result' as const,
+          pages,
+          workerHost: 'r.jina.ai',
+        };
+        return;
+      }
 
       // get endpoint
       const endpoint = (access.wssEndpoint || env.PUPPETEER_WSS_ENDPOINT || '').trim();
@@ -338,6 +369,90 @@ function _shortError(error: any): string {
   const name = error?.name || 'Error';
   const message = (error?.message || '').split('\n')[0].trim();
   return message ? `${name}: ${message}` : name;
+}
+
+
+// configuration
+const JINA_WORKER_TIMEOUT = 45 * 1000; // 45 seconds - Jina Reader can be slow on heavy pages
+
+/**
+ * Fetches a page via the Jina Reader API (https://r.jina.ai/<url>).
+ * Returns clean LLM-ready markdown - no browser required. No screenshots, no file downloads.
+ */
+async function workerJina(
+  targetUrl: string,
+  transforms: PageTransformSchema[],
+  apiKey: string,
+): Promise<FetchPageWorkerOutputSchema> {
+
+  const result: FetchPageWorkerOutputSchema = {
+    url: targetUrl,
+    title: '',
+    content: undefined,
+    file: undefined,
+    error: undefined,
+    stopReason: 'error',
+    screenshot: undefined,
+  };
+
+  // Jina Reader does not produce HTML - if that's all the caller wants, bail early
+  const wantsMarkdown = transforms.includes('markdown');
+  const wantsText = transforms.includes('text');
+  if (!wantsMarkdown && !wantsText) {
+    result.error = '[Jina] Reader provides markdown/text only (no raw HTML, no screenshots)';
+    return result;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`https://r.jina.ai/${targetUrl}`, {
+      headers: {
+        'Accept': 'application/json',
+        'X-Return-Format': 'markdown',
+        ...(apiKey ? { 'Authorization': `Bearer ${apiKey}` } : {}),
+      },
+      signal: AbortSignal.timeout(JINA_WORKER_TIMEOUT),
+    });
+  } catch (error: any) {
+    const isTimeout = error?.name === 'TimeoutError' || error?.name === 'AbortError';
+    result.stopReason = isTimeout ? 'timeout' : 'error';
+    result.error = '[Jina] ' + (isTimeout ? 'Request timed out' : (error?.message || 'Connection error'));
+    return result;
+  }
+
+  // parse the JSON envelope: { code, status, data: { title, url, content, ... } }
+  let envelope: any;
+  try {
+    envelope = await response.json();
+  } catch {
+    result.error = `[Jina] Invalid response (HTTP ${response.status})`;
+    return result;
+  }
+
+  if (!response.ok || !envelope?.data) {
+    const message = envelope?.readableMessage || envelope?.message || `HTTP ${response.status}`;
+    result.error = `[Jina] ${message}`;
+    if (response.status === 401 || envelope?.code === 401)
+      result.error = '[Jina] Authentication failed - check your Jina API key';
+    if (response.status === 429 || envelope?.code === 429)
+      result.error = '[Jina] Rate limited - add a Jina API key or try again later';
+    return result;
+  }
+
+  const markdown = typeof envelope.data.content === 'string' ? envelope.data.content : '';
+  if (!markdown.trim()) {
+    result.error = '[Jina] Empty content';
+    return result;
+  }
+
+  result.title = typeof envelope.data.title === 'string' ? envelope.data.title : '';
+  result.content = {};
+  if (wantsMarkdown)
+    result.content.markdown = markdown;
+  if (wantsText)
+    result.content.text = markdown; // markdown doubles as readable text
+  result.stopReason = 'end';
+  return result;
 }
 
 

--- a/src/modules/browse/store-module-browsing.tsx
+++ b/src/modules/browse/store-module-browsing.tsx
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware';
 
 import { CapabilityBrowsing } from '~/common/components/useCapabilities';
 import { getBackendCapabilities } from '~/modules/backend/store-backend-capabilities';
+import { isValidJinaApiKey, useJinaStore } from '~/modules/jina/store-module-jina';
 
 
 export type BrowsePageTransform = 'html' | 'text' | 'markdown';
@@ -59,10 +60,13 @@ export function useBrowseCapability(): CapabilityBrowsing {
 
   // external client state
   const { wssEndpoint, enableComposerAttach, enableReactTool, enablePersonaTool } = useBrowseStore();
+  const { jinaApiKey } = useJinaStore();
 
   // derived state
-  const isClientConfig = !!wssEndpoint;
-  const isClientValid = (wssEndpoint?.startsWith('wss://') && wssEndpoint?.length > 10) || (wssEndpoint?.startsWith('ws://') && wssEndpoint?.length > 9);
+  const isWssValid = (wssEndpoint?.startsWith('wss://') && wssEndpoint?.length > 10) || (wssEndpoint?.startsWith('ws://') && wssEndpoint?.length > 9);
+  const isJinaValid = isValidJinaApiKey(jinaApiKey); // empty WSS + valid Jina key (or server-side JINA_API_KEY) enables browsing
+  const isClientConfig = !!wssEndpoint || !!jinaApiKey;
+  const isClientValid = isWssValid || isJinaValid;
   const mayWork = isServerConfig || (isClientConfig && isClientValid);
 
   return {

--- a/src/modules/google/GoogleSearchSettings.tsx
+++ b/src/modules/google/GoogleSearchSettings.tsx
@@ -6,8 +6,10 @@ import KeyIcon from '@mui/icons-material/Key';
 import SearchIcon from '@mui/icons-material/Search';
 
 import { getBackendCapabilities } from '~/modules/backend/store-backend-capabilities';
+import { isValidJinaApiKey, useJinaStore } from '~/modules/jina/store-module-jina';
 
 import { ExternalLink } from '~/common/components/ExternalLink';
+import { FormInputKey } from '~/common/components/forms/FormInputKey';
 import { FormLabelStart } from '~/common/components/forms/FormLabelStart';
 import { Link } from '~/common/components/Link';
 
@@ -24,11 +26,17 @@ export function GoogleSearchSettings() {
     googleCSEId: state.googleCSEId, setGoogleCSEId: state.setGoogleCSEId,
     restrictToDomain: state.restrictToDomain, setRestrictToDomain: state.setRestrictToDomain,
   })));
+  const { jinaApiKey, setJinaApiKey } = useJinaStore(useShallow(state => ({
+    jinaApiKey: state.jinaApiKey,
+    setJinaApiKey: state.setJinaApiKey,
+  })));
 
 
   // derived state
   const isValidKey = googleCloudApiKey ? isValidGoogleCloudApiKey(googleCloudApiKey) : backendHasGoogle;
   const isValidId = googleCSEId ? isValidGoogleCseId(googleCSEId) : backendHasGoogle;
+  const isJinaValid = isValidJinaApiKey(jinaApiKey); // valid Jina key substitutes for Google PSE
+  const googleSatisfied = (isValidKey && isValidId) || isJinaValid;
 
 
   const handleGoogleApiKeyChange = (e: React.ChangeEvent<HTMLInputElement>) => setGoogleCloudApiKey(e.target.value);
@@ -41,15 +49,24 @@ export function GoogleSearchSettings() {
   return <>
 
     <Typography level='body-sm'>
-      For custom search engines or domain-specific searches. Most models have native search capabilities. Uses the Google <ExternalLink href='https://developers.google.com/custom-search/v1/overview'>Programmable Search Engine</ExternalLink> API.
+      For custom search engines or domain-specific searches. Most models have native search capabilities. Uses the Google <ExternalLink href='https://developers.google.com/custom-search/v1/overview'>Programmable Search Engine</ExternalLink> API, or <ExternalLink href='https://jina.ai'>Jina Search</ExternalLink> as an alternative (single key, no CSE setup).
     </Typography>
+
+    {/* Jina Search key - used when the Google PSE credentials below are not set */}
+    <FormInputKey
+      autoCompleteId='jina-search-key' label='Jina API Key'
+      description={<>Simplest option - get one at <Link href='https://jina.ai' noLinkStyle target='_blank'>jina.ai</Link></>}
+      value={jinaApiKey} onChange={setJinaApiKey}
+      required={false} isError={!!jinaApiKey && !isJinaValid}
+      placeholder='jina_...'
+    />
 
     <FormControl orientation='horizontal' sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
       <FormLabelStart title='GCP API Key'
                       description={<>Create one <Link href='https://console.cloud.google.com/apis/credentials' noLinkStyle target='_blank'>here</Link></>}
                       tooltip='Create your Google Cloud "API Key Credential" and enter it here' />
       <Input
-        variant='outlined' placeholder={backendHasGoogle ? '...' : 'missing'} error={!isValidKey}
+        variant='outlined' placeholder={backendHasGoogle ? '...' : (isJinaValid ? 'unused (Jina)' : 'missing')} error={!googleSatisfied && !isValidKey}
         value={googleCloudApiKey} onChange={handleGoogleApiKeyChange}
         startDecorator={<KeyIcon />}
         slotProps={{ input: { sx: { width: '100%' } } }}
@@ -62,7 +79,7 @@ export function GoogleSearchSettings() {
                       description={<>Get it <Link href='https://programmablesearchengine.google.com/' noLinkStyle target='_blank'>here</Link></>}
                       tooltip='Create your Google "Programmable Search Engine" and enter its ID here' />
       <Input
-        variant='outlined' placeholder={backendHasGoogle ? '...' : 'missing'} error={!isValidId}
+        variant='outlined' placeholder={backendHasGoogle ? '...' : (isJinaValid ? 'unused (Jina)' : 'missing')} error={!googleSatisfied && !isValidId}
         value={googleCSEId} onChange={handleCseIdChange}
         startDecorator={<SearchIcon />}
         slotProps={{ input: { sx: { width: '100%' } } }}

--- a/src/modules/google/search.client.ts
+++ b/src/modules/google/search.client.ts
@@ -1,5 +1,7 @@
 import { apiAsync } from '~/common/util/trpc.client';
 
+import { isValidJinaApiKey, useJinaStore } from '~/modules/jina/store-module-jina';
+
 import { Search } from './search.types';
 import { useGoogleSearchStore } from './store-module-google';
 
@@ -15,13 +17,22 @@ export async function callApiSearchGoogle(query: string, items: number, restrict
 
   // get the keys (empty if they're on server)
   const { googleCloudApiKey, googleCSEId, restrictToDomain: defaultRestrictToDomain } = useGoogleSearchStore.getState();
+  const { jinaApiKey } = useJinaStore.getState();
+
+  // use Jina Search when Google PSE isn't configured client-side but a Jina key is;
+  // when both are empty the server decides (env fallback: Google first, then JINA_API_KEY)
+  const hasGoogle = isValidGoogleCloudApiKey(googleCloudApiKey) && isValidGoogleCseId(googleCSEId);
+  const hasJina = isValidJinaApiKey(jinaApiKey);
+  const useJina = !hasGoogle && hasJina;
 
   try {
     return await apiAsync.googleSearch.search.query({
       query,
       items,
+      provider: useJina ? 'jina' : 'google',
       key: googleCloudApiKey,
       cx: googleCSEId,
+      ...(useJina && { jinaKey: jinaApiKey.trim() }),
       restrictToDomain: restrictToDomain || defaultRestrictToDomain || null,
     });
   } catch (error: any) {

--- a/src/modules/google/search.router.ts
+++ b/src/modules/google/search.router.ts
@@ -23,11 +23,59 @@ export const googleSearchRouter = createTRPCRouter({
     .input(z.object({
       query: z.string(),
       items: z.number(),
+      provider: z.enum(['google', 'jina']).optional(), // defaults to google for backwards compatibility
       key: z.string().optional(), // could be server-set
       cx: z.string().optional(), // could be server-set
+      jinaKey: z.string().optional(), // could be server-set (JINA_API_KEY)
       restrictToDomain: z.string().nullable(),
     }))
     .query(async ({ input }): Promise<{ pages: Search.API.BriefResult[] }> => {
+
+      // Jina Search (s.jina.ai) - used when requested, or when Google credentials
+      // are missing but a Jina key is available
+      const googleKey = (input.key || env.GOOGLE_CLOUD_API_KEY || '').trim();
+      const googleCx = (input.cx || env.GOOGLE_CSE_ID || '').trim();
+      const jinaKey = (input.jinaKey || env.JINA_API_KEY || '').trim();
+      const useJina = input.provider === 'jina' || ((!googleKey || !googleCx) && !!jinaKey);
+
+      if (useJina) {
+        if (!jinaKey)
+          throw new TRPCError({ code: 'PRECONDITION_FAILED', message: 'Missing Jina API Key (s.jina.ai requires one)' });
+
+        // domain restriction via the standard site: operator
+        const jinaQuery = input.restrictToDomain
+          ? `${input.query.trim()} site:${input.restrictToDomain.trim()}`
+          : input.query.trim();
+
+        const data: {
+          code?: number, status?: number,
+          data?: { title?: string, url?: string, description?: string, content?: string }[],
+          message?: string, readableMessage?: string,
+        } = await fetchJsonOrTRPCThrow({
+          url: `https://s.jina.ai/${encodeURIComponent(jinaQuery)}`,
+          name: 'Jina Search',
+          headers: {
+            'Accept': 'application/json',
+            'Accept-Encoding': 'gzip',
+            'Authorization': `Bearer ${jinaKey}`,
+            'User-Agent': 'Big-AGI (gzip)',
+          },
+        });
+
+        if (!data.data)
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: `Jina Search API error: ${data.readableMessage || data.message || 'unknown error'}`,
+          });
+
+        return {
+          pages: data.data.slice(0, input.items).map((result): Search.API.BriefResult => ({
+            title: result.title || '',
+            link: result.url || '',
+            snippet: result.description || '',
+          })),
+        };
+      }
 
       const customSearchParams: Search.Wire.RequestParams = {
         q: input.query.trim(),

--- a/src/modules/jina/store-module-jina.ts
+++ b/src/modules/jina/store-module-jina.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+
+/**
+ * Shared Jina AI (Reader r.jina.ai / Search s.jina.ai) settings.
+ * Single key, consumed by both the Browse module (browse-jina dialect) and
+ * the Search module (jina provider). Server-side equivalent: JINA_API_KEY env.
+ */
+
+interface ModuleJinaStore {
+
+  jinaApiKey: string;
+  setJinaApiKey: (key: string) => void;
+
+}
+
+export const useJinaStore = create<ModuleJinaStore>()(
+  persist(
+    (set) => ({
+
+      jinaApiKey: '',
+      setJinaApiKey: (jinaApiKey: string) => set({ jinaApiKey }),
+
+    }),
+    {
+      name: 'app-module-jina',
+    },
+  ),
+);
+
+// Jina keys look like 'jina_xxxxxxxx...'; be lenient on length, strict on prefix
+export const isValidJinaApiKey = (apiKey?: string) => !!apiKey && apiKey.trim().startsWith('jina_') && apiKey.trim().length >= 10;

--- a/src/server/env.server.ts
+++ b/src/server/env.server.ts
@@ -116,6 +116,9 @@ export const env = createEnv({
     GOOGLE_CLOUD_API_KEY: z.string().optional(),
     GOOGLE_CSE_ID: z.string().optional(),
 
+    // Jina AI Reader/Search (r.jina.ai / s.jina.ai)
+    JINA_API_KEY: z.string().optional(),
+
 
     // Text-To-Speech: ElevenLabs - speech.ts
     ELEVENLABS_API_KEY: z.string().optional(),

--- a/tests/jina-patch.test.mjs
+++ b/tests/jina-patch.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * Runnable test for the Jina patch (browse dialect + search provider).
+ *
+ * Run from the repo root:
+ *   node tests/jina-patch.test.mjs            # static + live keyless checks
+ *   JINA_API_KEY=jina_... node tests/jina-patch.test.mjs   # also tests s.jina.ai search
+ *
+ * What it verifies:
+ *  1. [static] the patch wiring is present in the modified source files
+ *  2. [live]   r.jina.ai returns the JSON envelope workerJina() expects (keyless, low rate limit)
+ *  3. [live]   the workerJina parsing logic maps the envelope to FetchPageWorkerOutputSchema shape
+ *  4. [live]   s.jina.ai returns the array-of-results shape the search router expects (needs key)
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const JINA_KEY = process.env.JINA_API_KEY || '';
+
+let failures = 0;
+function check(name, cond, extra = '') {
+  console.log(`${cond ? 'PASS' : 'FAIL'}  ${name}${extra ? '  (' + extra + ')' : ''}`);
+  if (!cond) failures++;
+}
+
+// --- 1. static wiring checks ---
+const browseRouter = readFileSync(join(root, 'src/modules/browse/browse.router.ts'), 'utf8');
+check('browse router: browse-jina dialect', browseRouter.includes("'browse-jina'"));
+check('browse router: workerJina defined', /async function workerJina\(/.test(browseRouter));
+check('browse router: env.JINA_API_KEY fallback', browseRouter.includes('env.JINA_API_KEY'));
+
+const browseClient = readFileSync(join(root, 'src/modules/browse/browse.client.ts'), 'utf8');
+check('browse client: dialect switch', browseClient.includes("dialect: 'browse-jina'"));
+
+const searchRouter = readFileSync(join(root, 'src/modules/google/search.router.ts'), 'utf8');
+check('search router: jina provider', searchRouter.includes("'jina'") && searchRouter.includes('https://s.jina.ai/'));
+
+const envServer = readFileSync(join(root, 'src/server/env.server.ts'), 'utf8');
+check('env.server: JINA_API_KEY declared', envServer.includes('JINA_API_KEY'));
+
+// --- 2/3. live r.jina.ai check (mirrors workerJina in browse.router.ts) ---
+async function workerJina(targetUrl, transforms, apiKey) {
+  const result = { url: targetUrl, title: '', content: undefined, error: undefined, stopReason: 'error' };
+  const wantsMarkdown = transforms.includes('markdown');
+  const wantsText = transforms.includes('text');
+  if (!wantsMarkdown && !wantsText) { result.error = 'html-only unsupported'; return result; }
+  const response = await fetch(`https://r.jina.ai/${targetUrl}`, {
+    headers: { 'Accept': 'application/json', 'X-Return-Format': 'markdown', ...(apiKey ? { 'Authorization': `Bearer ${apiKey}` } : {}) },
+    signal: AbortSignal.timeout(45000),
+  });
+  const envelope = await response.json();
+  if (!response.ok || !envelope?.data) { result.error = envelope?.readableMessage || `HTTP ${response.status}`; return result; }
+  const markdown = typeof envelope.data.content === 'string' ? envelope.data.content : '';
+  if (!markdown.trim()) { result.error = 'empty content'; return result; }
+  result.title = envelope.data.title || '';
+  result.content = {};
+  if (wantsMarkdown) result.content.markdown = markdown;
+  if (wantsText) result.content.text = markdown;
+  result.stopReason = 'end';
+  return result;
+}
+
+try {
+  const page = await workerJina('https://example.com', ['markdown', 'text'], JINA_KEY);
+  check('live: r.jina.ai fetch example.com', page.stopReason === 'end', page.error || `title="${page.title}"`);
+  check('live: markdown content present', !!page.content?.markdown?.includes('Example Domain'));
+  check('live: text transform filled', !!page.content?.text);
+  const htmlOnly = await workerJina('https://example.com', ['html'], JINA_KEY);
+  check('live: html-only request errors cleanly', !!htmlOnly.error && htmlOnly.stopReason === 'error');
+} catch (e) {
+  check('live: r.jina.ai fetch example.com', false, e.message);
+}
+
+// --- 4. live s.jina.ai check (needs a real key) ---
+if (JINA_KEY) {
+  try {
+    const res = await fetch(`https://s.jina.ai/${encodeURIComponent('what is big-agi')}`, {
+      headers: { 'Accept': 'application/json', 'Authorization': `Bearer ${JINA_KEY}` },
+      signal: AbortSignal.timeout(45000),
+    });
+    const data = await res.json();
+    const arr = data?.data;
+    check('live: s.jina.ai returns result array', Array.isArray(arr) && arr.length > 0, `${arr?.length} results`);
+    check('live: results have title/url/description', !!arr?.[0]?.title && !!arr?.[0]?.url);
+  } catch (e) {
+    check('live: s.jina.ai search', false, e.message);
+  }
+} else {
+  console.log('SKIP  s.jina.ai live search (set JINA_API_KEY to run)');
+}
+
+console.log(failures ? `\n${failures} FAILURE(S)` : '\nALL CHECKS PASSED');
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
## Summary

Adds [Jina AI](https://jina.ai) as an optional backend for both web tools, with no new runtime dependencies (plain `fetch`):

- **Browse**: new `browse-jina` dialect in the browse router - fetches pages server-side via Jina Reader, returning clean LLM-ready markdown. Used when no Puppeteer WSS endpoint is configured. Works keyless at Jina's anonymous rate limit; a key raises it.
- **Search**: Jina Search (`s.jina.ai`) as an alternative to Google Programmable Search - one API key, no CSE setup. Auto-selected when Google credentials are absent but a Jina key exists; "restrict to domain" maps to the `site:` operator.
- One shared key field surfaced in both settings panels (zustand store `app-module-jina`).
- Server-side `JINA_API_KEY` env var enables both tools instance-wide and is reflected in backend capabilities (`hasBrowsing`, `hasGoogleCustomSearch`).

## Why

- Browsing today requires a hosted browser (Puppeteer WSS endpoint) - the biggest setup hurdle for casual self-hosting. Reader needs no browser infrastructure at all.
- Search today needs two Google credentials (API key + CSE ID); Jina needs a single key.
- Both paths are additive: Google PSE and Puppeteer WSS are untouched and take priority when configured.

## Limitations

- Jina Reader returns markdown/text only - no screenshots, raw HTML, or file downloads through this dialect (the UI notes this).
- `s.jina.ai` requires an API key; `r.jina.ai` does not (rate-limited).

## Testing

- `tests/jina-patch.test.mjs` (run: `node tests/jina-patch.test.mjs`): static wiring checks plus live r.jina.ai/s.jina.ai response-shape validation - keyless and keyed.
- `tsc --noEmit` clean; production `next build` passes.
- Running in production on a Vercel hobby deployment.