### PR TITLE
Chat: age-based filter in the drawer (bulk-delete old chats)

### DIFF
--- a/src/apps/chat/components/layout-drawer/ChatDrawer.tsx
+++ b/src/apps/chat/components/layout-drawer/ChatDrawer.tsx
@@ -36,6 +36,7 @@ import { ChatDrawerStorageWarning } from './ChatDrawerStorageWarning';
 import { ChatFolderList } from './folders/ChatFolderList';
 import { ChatNavGrouping, ChatSearchDepth, ChatSearchSorting, isDrawerSearching, useChatDrawerRenderItems } from './useChatDrawerRenderItems';
 import { ClearFolderText } from '../layout-bar/useFolderDropdown';
+import { AGE_FILTER_OPTIONS } from './ageFilter';
 import { useChatDrawerFilters } from '../../store-app-chat';
 
 
@@ -95,12 +96,13 @@ function ChatDrawer(props: {
     filterHasImageAssets, toggleFilterHasImageAssets,
     filterHasStars, toggleFilterHasStars,
     filterIsArchived, toggleFilterIsArchived,
+    filterOlderThanDays, setFilterOlderThanDays,
     showPersonaIcons, toggleShowPersonaIcons,
     showRelativeSize, toggleShowRelativeSize,
   } = useChatDrawerFilters();
   const { activeFolder, allFolders, enableFolders, toggleEnableFolders } = useFolders(props.activeFolderId);
   const { filteredChatsCount, filteredChatIDs, filteredChatsAreEmpty, filteredChatsBarBasis, filteredChatsIncludeActive, renderNavItems } = useChatDrawerRenderItems(
-    props.activeConversationId, props.chatPanesConversationIds, debouncedSearchQuery, activeFolder, allFolders, filterHasBeamOpen, filterHasStars, filterHasImageAssets, filterHasDocFragments, filterIsArchived, navGrouping, searchSorting, showRelativeSize, searchDepth,
+    props.activeConversationId, props.chatPanesConversationIds, debouncedSearchQuery, activeFolder, allFolders, filterHasBeamOpen, filterHasStars, filterHasImageAssets, filterHasDocFragments, filterIsArchived, filterOlderThanDays, navGrouping, searchSorting, showRelativeSize, searchDepth,
   );
   const [uiComplexityMode, contentScaling] = useUIPreferencesStore(useShallow((state) => [state.complexityMode, state.contentScaling]));
   const zenMode = uiComplexityMode === 'minimal';
@@ -248,6 +250,25 @@ function ChatDrawer(props: {
             Beam Open <ChatBeamIcon />
           </MenuItem>
 
+          {/* Age filter (compact chip row for mobile) */}
+          <ListDivider />
+          <ListItem sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
+            <Typography level='body-sm' sx={{ mr: 0.5 }}>Age</Typography>
+            {AGE_FILTER_OPTIONS.map(({ days, label, shortLabel }) => (
+              <Button
+                key={label}
+                aria-label={label}
+                size='sm'
+                variant={filterOlderThanDays === days ? 'solid' : 'soft'}
+                color={filterOlderThanDays === days ? 'primary' : 'neutral'}
+                onClick={() => setFilterOlderThanDays(days)}
+                sx={{ minHeight: 0, px: 1, fontSize: 'xs', borderRadius: 'sm' }}
+              >
+                {shortLabel}
+              </Button>
+            ))}
+          </ListItem>
+
           <ListDivider />
           <ListItem>
             <Typography level='body-sm'>Show</Typography>
@@ -295,8 +316,8 @@ function ChatDrawer(props: {
       )}
     </Dropdown>
   ), [
-    filterHasBeamOpen, filterHasDocFragments, filterHasImageAssets, filterHasStars, isSearching, navGrouping, searchSorting, searchDepth, filterIsArchived, showPersonaIcons, showRelativeSize,
-    toggleFilterHasBeamOpen, toggleFilterHasDocFragments, toggleFilterHasImageAssets, toggleFilterHasStars, toggleFilterIsArchived, toggleShowPersonaIcons, toggleShowRelativeSize,
+    filterHasBeamOpen, filterHasDocFragments, filterHasImageAssets, filterHasStars, isSearching, navGrouping, searchSorting, searchDepth, filterIsArchived, showPersonaIcons, showRelativeSize, filterOlderThanDays,
+    toggleFilterHasBeamOpen, toggleFilterHasDocFragments, toggleFilterHasImageAssets, toggleFilterHasStars, toggleFilterIsArchived, toggleShowPersonaIcons, toggleShowRelativeSize, setFilterOlderThanDays,
   ]);
 
   const displayNavItems = React.useMemo(() => {
@@ -315,7 +336,7 @@ function ChatDrawer(props: {
   // when filters/search transition from active to inactive, the active chat may end up
   // submerged below the fold of a much longer list - scroll it back into view
   const chatsListRef = React.useRef<HTMLDivElement>(null);
-  const isFiltering = isSearching || filterHasBeamOpen || filterHasDocFragments || filterHasImageAssets || filterHasStars || filterIsArchived;
+  const isFiltering = isSearching || filterHasBeamOpen || filterHasDocFragments || filterHasImageAssets || filterHasStars || filterIsArchived || filterOlderThanDays !== null;
   React.useLayoutEffect(() => {
     if (isFiltering) return;
     const activeEl = chatsListRef.current?.querySelector('[aria-current="true"]') as HTMLElement | null;
@@ -441,7 +462,7 @@ function ChatDrawer(props: {
                 {filterHasStars && <StarOutlineRoundedIcon sx={{ color: 'primary.softColor', fontSize: 'xl', mb: -0.5, mr: 1 }} />}
                 {item.message}
               </Typography>
-              {(filterHasBeamOpen || filterHasStars || filterHasImageAssets || filterHasDocFragments || filterIsArchived) && (
+              {(filterHasBeamOpen || filterHasStars || filterHasImageAssets || filterHasDocFragments || filterIsArchived || filterOlderThanDays !== null) && (
                 <Tooltip title='Clear Filters'>
                   <IconButton size='sm' color='primary' onClick={clearFilters}>
                     <ClearIcon />

--- a/src/apps/chat/components/layout-drawer/ageFilter.test.ts
+++ b/src/apps/chat/components/layout-drawer/ageFilter.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { filterOlderThanMatches, AGE_FILTER_OPTIONS } from './ageFilter';
+
+const NOW = Date.UTC(2026, 7, 18, 12, 0, 0); // fixed reference
+const daysAgo = (n: number) => NOW - n * 24 * 60 * 60 * 1000;
+
+test('null cutoff matches everything', () => {
+  assert.equal(filterOlderThanMatches(daysAgo(400), null, NOW), true);
+  assert.equal(filterOlderThanMatches(daysAgo(0), null, NOW), true);
+});
+
+test('14-day cutoff: older matches, newer does not', () => {
+  assert.equal(filterOlderThanMatches(daysAgo(15), 14, NOW), true);
+  assert.equal(filterOlderThanMatches(daysAgo(13), 14, NOW), false);
+});
+
+test('boundary: exactly N days old does NOT match (strictly older)', () => {
+  assert.equal(filterOlderThanMatches(daysAgo(30), 30, NOW), false);
+  assert.equal(filterOlderThanMatches(daysAgo(30) - 1, 30, NOW), true);
+});
+
+test('presets include 7/14/30/90 days', () => {
+  assert.deepEqual(AGE_FILTER_OPTIONS.map(o => o.days), [null, 7, 14, 30, 90]);
+});

--- a/src/apps/chat/components/layout-drawer/ageFilter.ts
+++ b/src/apps/chat/components/layout-drawer/ageFilter.ts
@@ -1,0 +1,19 @@
+// pure logic for the drawer "Older than" filter - import-free for tsx --test
+
+export const AGE_FILTER_OPTIONS: { days: number | null; label: string; shortLabel: string }[] = [
+  { days: null, label: 'Any age', shortLabel: 'Any' },
+  { days: 7, label: 'Older than 1 week', shortLabel: '>1w' },
+  { days: 14, label: 'Older than 2 weeks', shortLabel: '>2w' },
+  { days: 30, label: 'Older than 1 month', shortLabel: '>1m' },
+  { days: 90, label: 'Older than 3 months', shortLabel: '>3m' },
+];
+
+/**
+ * Returns true if a conversation with last-activity `updatedAtMs`
+ * should be SHOWN under the "older than `cutoffDays`" filter.
+ * null cutoff = no filtering. Strictly-older comparison.
+ */
+export function filterOlderThanMatches(updatedAtMs: number, cutoffDays: number | null, nowMs: number = Date.now()): boolean {
+  if (cutoffDays === null) return true;
+  return updatedAtMs < nowMs - cutoffDays * 24 * 60 * 60 * 1000;
+}

--- a/src/apps/chat/components/layout-drawer/useChatDrawerRenderItems.tsx
+++ b/src/apps/chat/components/layout-drawer/useChatDrawerRenderItems.tsx
@@ -5,6 +5,7 @@ import { useModuleBeamStore } from '~/modules/beam/store-module-beam';
 import type { DFolder } from '~/common/stores/folders/store-chat-folders';
 import { DMessage, DMessageUserFlag, MESSAGE_FLAG_STARRED, messageFragmentsReduceText, messageHasUserFlag, messageUserFlagToEmoji } from '~/common/stores/chat/chat.message';
 import { conversationTitle, DConversationId } from '~/common/stores/chat/chat.conversation';
+import { filterOlderThanMatches } from './ageFilter';
 import { createTimeBucketClassifierEn } from '~/common/util/timeUtils';
 import { isAttachmentFragment, isContentOrAttachmentFragment, isDocPart, isImageRefPart, isZyncAssetImageReferencePart } from '~/common/stores/chat/chat.fragments';
 import { shallowEquals } from '~/common/util/hooks/useShallowObject';
@@ -91,6 +92,7 @@ export function useChatDrawerRenderItems(
   filterHasImageAssets: boolean,
   filterHasDocFragments: boolean,
   filterIsArchived: boolean,
+  filterOlderThanDays: number | null,
   grouping: ChatNavGrouping,
   searchSorting: ChatSearchSorting,
   showRelativeSize: boolean,
@@ -123,11 +125,15 @@ export function useChatDrawerRenderItems(
       const conversationsInFolder = !activeFolder ? conversations
         : conversations.filter(_c => activeFolder.conversationIds.includes(_c.id));
 
+      // filter 1.5: last-activity older than the selected cutoff
+      const conversationsInAge = filterOlderThanDays === null ? conversationsInFolder
+        : conversationsInFolder.filter(_c => filterOlderThanMatches(_c.updated || _c.created || 0, filterOlderThanDays));
+
       // filter 2: preparation: lowercase the query
       const { isSearching, lcTextQuery } = isDrawerSearching(filterByQuery);
 
       // transform (the conversations into ChatNavigationItemData) + filter2 (if searching)
-      const chatNavItems = conversationsInFolder
+      const chatNavItems = conversationsInAge
         .map((_c): ChatNavigationItemData | null => {
 
           // optimized reduction to find stars/images/docs/and lowercased text for search

--- a/src/apps/chat/store-app-chat.ts
+++ b/src/apps/chat/store-app-chat.ts
@@ -65,6 +65,9 @@ interface AppChatStore {
   filterIsArchived: boolean;
   toggleFilterIsArchived: () => void;
 
+  filterOlderThanDays: number | null;
+  setFilterOlderThanDays: (days: number | null) => void;
+
   micTimeoutMs: number;
   setMicTimeoutMs: (micTimeoutMs: number) => void;
 
@@ -130,7 +133,7 @@ const useAppChatStore = create<AppChatStore>()(persist(
 
     // Chat UI
 
-    clearFilters: () => _set({ filterIsArchived: false, filterHasBeamOpen: false, filterHasDocFragments: false, filterHasImageAssets: false, filterHasStars: false }),
+    clearFilters: () => _set({ filterIsArchived: false, filterHasBeamOpen: false, filterHasDocFragments: false, filterHasImageAssets: false, filterHasStars: false, filterOlderThanDays: null }),
 
     filterHasBeamOpen: false,
     toggleFilterHasBeamOpen: () => _set(({ filterHasBeamOpen }) => ({ filterHasBeamOpen: !filterHasBeamOpen })),
@@ -146,6 +149,9 @@ const useAppChatStore = create<AppChatStore>()(persist(
 
     filterIsArchived: false,
     toggleFilterIsArchived: () => _set(({ filterIsArchived }) => ({ filterIsArchived: !filterIsArchived })),
+
+    filterOlderThanDays: null,
+    setFilterOlderThanDays: (filterOlderThanDays: number | null) => _set({ filterOlderThanDays }),
 
     micTimeoutMs: 5000,
     setMicTimeoutMs: (micTimeoutMs: number) => _set({ micTimeoutMs }),
@@ -268,9 +274,11 @@ export function useChatDrawerFilters() {
     filterHasImageAssets: state.filterHasImageAssets,
     filterHasStars: state.filterHasStars,
     filterIsArchived: state.filterIsArchived,
+    filterOlderThanDays: state.filterOlderThanDays,
     showPersonaIcons: state.showPersonaIcons2,
     showRelativeSize: state.showRelativeSize,
     clearFilters: state.clearFilters,
+    setFilterOlderThanDays: state.setFilterOlderThanDays,
     toggleFilterHasBeamOpen: state.toggleFilterHasBeamOpen,
     toggleFilterHasDocFragments: state.toggleFilterHasDocFragments,
     toggleFilterHasImageAssets: state.toggleFilterHasImageAssets,


### PR DESCRIPTION
## Summary

Adds an **"Older than"** age filter to the chat drawer's view-options menu: 1 week / 2 weeks / 1 month / 3 months, based on last activity (`updated ?? created`).

The drawer currently only supports deleting chats individually or deleting *all* of them. Because the existing **"Delete all N chats"** button already operates on the filtered set (with a confirmation dialog showing the exact count), a single new filter unlocks the commonly requested "delete chats from the past month" workflow — no new delete plumbing needed.

- `ageFilter.ts`: pure, import-free predicate + presets, covered by `tsx --test` unit tests
- `store-app-chat.ts`: persisted `filterOlderThanDays` (default `null` = off), wired into `clearFilters` and `useChatDrawerFilters()`
- `useChatDrawerRenderItems.tsx`: age predicate applied after archival/folder filters
- `ChatDrawer.tsx`: compact chip row in the view-options menu (mobile-friendly, single row), included in `isFiltering` / Clear-Filters affordance

The filter composes with the existing ones (folders, starred, search) and persists across reloads.

## Test plan

- [x] `npm run tscheck` clean
- [x] `npm run lint` clean (changed files)
- [x] `npm test` — 26 tests, 0 failures (4 new covering the predicate: null cutoff, 14d cutoff, strict boundary, presets)
- [x] Manual: drawer > view options > Age chips narrow the list; "Delete all N chats" count matches; Clear Filters resets; survives reload
