### PR TITLE
Add Confetti celebration for first diagram generated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@vercel/speed-insights": "^2.0.0",
         "aws4fetch": "^1.0.20",
         "browser-fs-access": "^0.38.0",
+        "canvas-confetti": "^1.9.3",
         "cheerio": "^1.1.2",
         "csv-stringify": "^6.8.3",
         "dexie": "~4.0.11",
@@ -49,6 +50,7 @@
         "prismjs": "^1.30.0",
         "puppeteer-core": "^24",
         "react": "^18",
+        "react-canvas-confetti": "^2.0.7",
         "react-dom": "^18",
         "react-hook-form": "^7.85.0",
         "react-markdown": "^10.1.0",
@@ -68,6 +70,7 @@
       },
       "devDependencies": {
         "@posthog/nextjs-config": "~1.6",
+        "@types/canvas-confetti": "^1.9.0",
         "@types/node": "^22",
         "@types/nprogress": "^0.2.3",
         "@types/prismjs": "^1.26.6",
@@ -3086,22 +3089,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@posthog/cli/node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
-      "extraneous": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/@posthog/cli/node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3459,6 +3446,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -4980,6 +4973,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -10596,6 +10599,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-canvas-confetti": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/react-canvas-confetti/-/react-canvas-confetti-2.0.7.tgz",
+      "integrity": "sha512-DIj44O35TPAwJkUSIZqWdVsgAMHtVf8h7YNmnr3jF3bn5mG+d7Rh9gEcRmdJfYgRzh6K+MAGujwUoIqQyLnMJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/canvas-confetti": "^1.6.4",
+        "canvas-confetti": "^1.9.2"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@vercel/speed-insights": "^2.0.0",
     "aws4fetch": "^1.0.20",
     "browser-fs-access": "^0.38.0",
+    "canvas-confetti": "^1.9.3",
     "cheerio": "^1.1.2",
     "csv-stringify": "^6.8.3",
     "dexie": "~4.0.11",
@@ -69,6 +70,7 @@
     "puppeteer-core": "^24",
     "react": "^18",
     "react-dom": "^18",
+    "react-canvas-confetti": "^2.0.7",
     "react-hook-form": "^7.85.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3.0.6",
@@ -87,6 +89,7 @@
   },
   "devDependencies": {
     "@posthog/nextjs-config": "~1.6",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^22",
     "@types/nprogress": "^0.2.3",
     "@types/prismjs": "^1.26.6",

--- a/src/common/components/confetti/ConfettiTrigger.tsx
+++ b/src/common/components/confetti/ConfettiTrigger.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+
+// dynamically imported: keep the canvas + confetti bundle out of the main chunk,
+// and make sure the underlying <canvas> is fully unmounted (not just hidden)
+// whenever no celebration is in flight
+const ReactCanvasConfettiLazy = React.lazy(() => import('react-canvas-confetti'));
+
+// the `confetti` instance handed to `onInit` - inferred rather than imported,
+// since react-canvas-confetti's compiled .d.ts doesn't re-export the type name
+type TCanvasConfettiInstance = Parameters<NonNullable<React.ComponentProps<typeof ReactCanvasConfettiLazy>['onInit']>>[0]['confetti'];
+
+
+/**
+ * Fires a short, theme-colored confetti burst, then unmounts its <canvas>.
+ *
+ * Meant as a lightweight reward for milestones (e.g.: first voice call > 1min,
+ * a new release, the first diagram generated, adding a local model provider,
+ * accepting a flattened conversation, ...) - see #209.
+ *
+ * Usage: bump `fireKey` (e.g. a counter, or Date.now()) every time you want
+ * a new burst; the component only exists in the tree (and only loads its
+ * chunk) while a burst is pending.
+ */
+export function ConfettiTrigger(props: { fireKey: number | string | null }) {
+
+  // no key (yet) -> render nothing, don't even load the chunk
+  if (props.fireKey === null || props.fireKey === undefined)
+    return null;
+
+  return (
+    <React.Suspense fallback={null}>
+      <ConfettiBurst fireKey={props.fireKey} />
+    </React.Suspense>
+  );
+}
+
+
+function ConfettiBurst(props: { fireKey: number | string }) {
+
+  // state
+  const [done, setDone] = React.useState(false);
+  const confettiRef = React.useRef<TCanvasConfettiInstance | null>(null);
+
+  // reset when a new burst is requested
+  React.useEffect(() => {
+    setDone(false);
+  }, [props.fireKey]);
+
+  // fire once mounted (or when the key changes) - then self-unmount
+  React.useEffect(() => {
+    if (done) return;
+    const confetti = confettiRef.current;
+    if (!confetti) return;
+
+    void confetti({
+      particleCount: 100,
+      spread: 70,
+      origin: { y: 0.6 },
+      // theme-colored, so it doesn't clash with the app's palette (Joy UI CSS vars)
+      colors: [
+        getCssVar('--joy-palette-primary-500') || '#0B6BCB',
+        getCssVar('--joy-palette-neutral-500') || '#5A6B7B',
+      ],
+    })?.then(() => setDone(true));
+  }, [done, props.fireKey]);
+
+  // fully gone once the animation has run - no lingering canvas element
+  if (done)
+    return null;
+
+  return (
+    <ReactCanvasConfettiLazy
+      onInit={({ confetti }) => {
+        confettiRef.current = confetti;
+      }}
+    />
+  );
+}
+
+
+function getCssVar(name: string): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const value = getComputedStyle(document.documentElement).getPropertyValue(name);
+  return value?.trim() || undefined;
+}

--- a/src/common/components/confetti/ConfettiTrigger.tsx
+++ b/src/common/components/confetti/ConfettiTrigger.tsx
@@ -39,18 +39,20 @@ function ConfettiBurst(props: { fireKey: number | string }) {
 
   // state
   const [done, setDone] = React.useState(false);
-  const confettiRef = React.useRef<TCanvasConfettiInstance | null>(null);
+  // NOTE: this is state (not a ref) on purpose - `<ReactCanvasConfettiLazy>` is behind
+  // React.lazy/Suspense, so it mounts in a later commit than this component. A ref set
+  // from its onInit wouldn't re-trigger the "fire" effect below, which would then have
+  // already run once (while the instance was still unset) and never run again.
+  const [confetti, setConfetti] = React.useState<TCanvasConfettiInstance | null>(null);
 
   // reset when a new burst is requested
   React.useEffect(() => {
     setDone(false);
   }, [props.fireKey]);
 
-  // fire once mounted (or when the key changes) - then self-unmount
+  // fire once the confetti instance is available (or when the key changes) - then self-unmount
   React.useEffect(() => {
-    if (done) return;
-    const confetti = confettiRef.current;
-    if (!confetti) return;
+    if (done || !confetti) return;
 
     void confetti({
       particleCount: 100,
@@ -62,7 +64,7 @@ function ConfettiBurst(props: { fireKey: number | string }) {
         getCssVar('--joy-palette-neutral-500') || '#5A6B7B',
       ],
     })?.then(() => setDone(true));
-  }, [done, props.fireKey]);
+  }, [confetti, done, props.fireKey]);
 
   // fully gone once the animation has run - no lingering canvas element
   if (done)
@@ -70,9 +72,7 @@ function ConfettiBurst(props: { fireKey: number | string }) {
 
   return (
     <ReactCanvasConfettiLazy
-      onInit={({ confetti }) => {
-        confettiRef.current = confetti;
-      }}
+      onInit={({ confetti }) => setConfetti(() => confetti)}
     />
   );
 }

--- a/src/common/stores/store-celebrations.ts
+++ b/src/common/stores/store-celebrations.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand/index';
+import { persist } from 'zustand/middleware';
+
+
+/// Store ///
+
+interface CelebrationsStore {
+
+  /**
+   * Set of milestone keys that have already been celebrated (confetti fired),
+   * so we only ever celebrate each one once per device.
+   */
+  celebratedMilestones: string[];
+
+}
+
+const useCelebrationsStore = create<CelebrationsStore>()(persist(
+  (): CelebrationsStore => ({
+
+    // initial state
+    celebratedMilestones: [],
+
+  }),
+  {
+    name: 'app-celebrations',
+    version: 1,
+  },
+));
+
+
+/// Milestones ///
+
+export type CelebrationMilestone =
+  | 'first-diagram-generated'
+  ;
+
+/**
+ * Marks `milestone` as celebrated and returns whether this was the first time
+ * (i.e. whether the caller should actually fire the confetti).
+ * Safe to call every time the underlying event happens - only fires once ever.
+ */
+export function celebrationConsumeMilestone(milestone: CelebrationMilestone): boolean {
+  const { celebratedMilestones } = useCelebrationsStore.getState();
+  if (celebratedMilestones.includes(milestone))
+    return false;
+
+  useCelebrationsStore.setState({
+    celebratedMilestones: [...celebratedMilestones, milestone],
+  });
+  return true;
+}

--- a/src/common/stores/store-celebrations.ts
+++ b/src/common/stores/store-celebrations.ts
@@ -38,6 +38,12 @@ export type CelebrationMilestone =
  * Marks `milestone` as celebrated and returns whether this was the first time
  * (i.e. whether the caller should actually fire the confetti).
  * Safe to call every time the underlying event happens - only fires once ever.
+ *
+ * NOTE: zustand's persist middleware hydrates from storage asynchronously, so if this
+ * is called before hydration completes on a cold load, it could fire once more than
+ * intended. Same tradeoff as the other persisted stores in this folder (e.g.
+ * store-client.ts) - acceptable here since the cost is just an extra confetti burst,
+ * not a data-integrity issue.
  */
 export function celebrationConsumeMilestone(milestone: CelebrationMilestone): boolean {
   const { celebratedMilestones } = useCelebrationsStore.getState();

--- a/src/modules/aifn/digrams/DiagramsModal.tsx
+++ b/src/modules/aifn/digrams/DiagramsModal.tsx
@@ -10,11 +10,13 @@ import { aixChatGenerateText_Simple } from '~/modules/aix/client/aix.client';
 
 import { AppBreadcrumbs } from '~/common/components/AppBreadcrumbs';
 import { ChipToggleButton } from '~/common/components/ChipToggleButton';
+import { ConfettiTrigger } from '~/common/components/confetti/ConfettiTrigger';
 import { ConversationsManager } from '~/common/chat-overlay/ConversationsManager';
 import { GoodModal } from '~/common/components/modals/GoodModal';
 import { PhTreeStructure } from '~/common/components/icons/phosphor/PhTreeStructure';
 import { InlineError } from '~/common/components/InlineError';
 import { adjustContentScaling } from '~/common/app.theme';
+import { celebrationConsumeMilestone } from '~/common/stores/store-celebrations';
 import { createDMessageTextContent, messageFragmentsReduceText } from '~/common/stores/chat/chat.message';
 import { splitSystemMessageFromHistory } from '~/common/stores/chat/chat.conversation';
 import { useFormRadio } from '~/common/components/forms/useFormRadio';
@@ -63,6 +65,7 @@ export function DiagramsModal(props: { config: DiagramConfig, onClose: () => voi
   const [customInstruction, setCustomInstruction] = React.useState<string>('');
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const [abortController, setAbortController] = React.useState<AbortController | null>(null);
+  const [celebrationKey, setCelebrationKey] = React.useState<number | null>(null);
 
   // external state
   const isMobile = useIsMobile();
@@ -119,6 +122,10 @@ export function DiagramsModal(props: { config: DiagramConfig, onClose: () => voi
           !!text && setDiagramCode(diagramCode = text.trim());
         },
       );
+
+      // celebrate the user's first ever successfully generated diagram
+      if (diagramCode && celebrationConsumeMilestone('first-diagram-generated'))
+        setCelebrationKey(Date.now());
     } catch (error: any) {
       setDiagramCode(null);
       setErrorMessage(error?.name !== 'AbortError' ? error?.message : 'Interrupted.');
@@ -180,6 +187,8 @@ export function DiagramsModal(props: { config: DiagramConfig, onClose: () => voi
 
 
   return (
+    <>
+    <ConfettiTrigger fireKey={celebrationKey} />
     <GoodModal
       // titleStartDecorator={<AutoFixHighIcon sx={{ fontSize: 'md', mr: 1 }} />}
       title={<Box sx={{ flex: 1, display: 'flex', alignItems: 'center' }}>
@@ -300,5 +309,6 @@ export function DiagramsModal(props: { config: DiagramConfig, onClose: () => voi
       </Box>
 
     </GoodModal>
+    </>
   );
 }

--- a/src/modules/aifn/digrams/DiagramsModal.tsx
+++ b/src/modules/aifn/digrams/DiagramsModal.tsx
@@ -124,7 +124,9 @@ export function DiagramsModal(props: { config: DiagramConfig, onClose: () => voi
       );
 
       // celebrate the user's first ever successfully generated diagram
-      if (diagramCode && celebrationConsumeMilestone('first-diagram-generated'))
+      // (guard against the 'Loading...' placeholder: only count it if the
+      // streaming callback above ever actually replaced it with real text)
+      if (diagramCode && diagramCode !== 'Loading...' && celebrationConsumeMilestone('first-diagram-generated'))
         setCelebrationKey(Date.now());
     } catch (error: any) {
       setDiagramCode(null);


### PR DESCRIPTION
## Summary
Implements a first, focused piece of #209 (Add Confetti): fires a theme-colored confetti burst the first time a user successfully generates a diagram, then fully unmounts it.

## What changed
- `ConfettiTrigger.tsx`: lazy-loads `react-canvas-confetti` so the canvas/confetti bundle stays out of the main chunk. The `<canvas>` is fully unmounted (not just hidden) once the burst finishes, per the issue's efficiency requirement.
- `store-celebrations.ts`: a small persisted zustand store (same shape as the existing `store-client.ts`) tracking which one-off milestones have already been celebrated, so a given milestone only ever fires once per device.
- Wired into `DiagramsModal.tsx`'s existing generation-success path.
- Colors come from the Joy UI theme CSS vars (`--joy-palette-primary-500` / `--joy-palette-neutral-500`) with static fallbacks, so it matches the active theme instead of hardcoded colors.

## Why only one milestone
The issue lists several trigger points (first >1min call, new release, first diagram, adding a local model provider, accepting a flattened conversation). Rather than half-wire all of them, I picked one (first diagram generated) and implemented it end-to-end, verified. `celebrationConsumeMilestone()` is written so the other triggers can reuse the same store in follow-up PRs — happy to add more if that's wanted here instead.

## Verified locally
- `npm ci` (matches CI's install step) succeeds with the updated `package-lock.json`.
- `npx tsc --noEmit` — no errors in the new/changed files.
- `npm run lint` — clean.

Towards #209