### PR TITLE
Add Gandr as a Speex TTS vendor

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -60,6 +60,8 @@ GOOGLE_CSE_ID=
 ELEVENLABS_API_KEY=
 ELEVENLABS_API_HOST=
 ELEVENLABS_VOICE_ID=
+# Text-To-Speech: Gandr
+GANDR_API_KEY=
 
 # Backend HTTP Basic Authentication (see `deploy-authentication.md` for turning on authentication)
 HTTP_BASIC_AUTH_USERNAME=
@@ -134,6 +136,7 @@ Enable the app to Talk, Draw, and Google things up.
 | `ELEVENLABS_API_KEY`       | ElevenLabs API Key - used for calls, etc.                                                                               |
 | `ELEVENLABS_API_HOST`      | Custom host for ElevenLabs                                                                                              |
 | `ELEVENLABS_VOICE_ID`      | Default voice ID for ElevenLabs                                                                                         |
+| `GANDR_API_KEY`            | Gandr API Key - used for calls, etc.                                                                    |
 |                            | *Note: OpenAI TTS and LocalAI TTS reuse credentials from your configured LLM services (no separate env vars needed)*   |
 | **Google Custom Search**   | [Google Programmable Search Engine](https://programmablesearchengine.google.com/about/)  produces links to pages        |
 | `GOOGLE_CLOUD_API_KEY`     | Google Cloud API Key, used with the '/react' command - [Link to GCP](https://console.cloud.google.com/apis/credentials) |

--- a/src/modules/speex/protocols/rpc/rpc.wiretypes.ts
+++ b/src/modules/speex/protocols/rpc/rpc.wiretypes.ts
@@ -15,6 +15,7 @@ export type SpeexSpeechParticle =
 
 export type SpeexWire_Access = z.infer<typeof SpeexWire.Access_schema>;
 export type SpeexWire_Access_ElevenLabs = z.infer<typeof SpeexWire.AccessElevenLabs_schema>;
+export type SpeexWire_Access_Gandr = z.infer<typeof SpeexWire.AccessGandr_schema>;
 export type SpeexWire_Access_Inworld = z.infer<typeof SpeexWire.AccessInworld_schema>;
 export type SpeexWire_Access_OpenAI = z.infer<typeof SpeexWire.AccessOpenAI_schema>;
 
@@ -40,6 +41,12 @@ export namespace SpeexWire {
     apiHost: z.string().optional(),
   });
 
+  export const AccessGandr_schema = z.object({
+    dialect: z.literal('gandr'),
+    apiKey: z.string(),
+    apiHost: z.string().optional(), // defaults to tts.gandr.ai
+  });
+
   export const AccessInworld_schema = z.object({
     dialect: z.literal('inworld'),
     apiKey: z.string(),             // base64-encoded API key from Inworld Portal
@@ -54,7 +61,7 @@ export namespace SpeexWire {
   });
 
   export const Access_schema = z.discriminatedUnion('dialect',
-    [AccessElevenLabs_schema, AccessInworld_schema, AccessOpenAI_schema],
+    [AccessElevenLabs_schema, AccessGandr_schema, AccessInworld_schema, AccessOpenAI_schema],
   );
 
 
@@ -63,6 +70,12 @@ export namespace SpeexWire {
   export const VoiceElevenLabs_schema = z.object({
     dialect: z.literal('elevenlabs'),
     ttsModel: z.string().optional(),
+    ttsVoiceId: z.string().optional(),
+  });
+
+  export const VoiceGandr_schema = z.object({
+    dialect: z.literal('gandr'),
+    ttsModel: z.enum(['tts-1']).optional(),
     ttsVoiceId: z.string().optional(),
   });
 
@@ -90,7 +103,7 @@ export namespace SpeexWire {
   });
 
   export const Voice_schema = z.discriminatedUnion('dialect',
-    [VoiceElevenLabs_schema, VoiceInworld_schema, VoiceLocalAI_schema, VoiceOpenAI_schema],
+    [VoiceElevenLabs_schema, VoiceGandr_schema, VoiceInworld_schema, VoiceLocalAI_schema, VoiceOpenAI_schema],
   );
 
 

--- a/src/modules/speex/protocols/rpc/synthesize-gandr.ts
+++ b/src/modules/speex/protocols/rpc/synthesize-gandr.ts
@@ -1,0 +1,122 @@
+import * as z from 'zod/v4';
+
+import { fetchResponseOrTRPCThrow } from '~/server/trpc/trpc.router.fetchers';
+
+import type { SpeexSpeechParticle, SpeexWire_Access_Gandr, SpeexWire_VoiceOption } from './rpc.wiretypes';
+import type { SynthesizeBackendFn } from './synthesize.core';
+import { SPEEX_DEBUG, SPEEX_DEFAULTS } from '../../speex.config';
+import { returnAudioWholeOrThrow, streamAudioChunksOrThrow } from './rpc.streaming';
+
+
+// configuration
+const MIN_CHUNK_SIZE = 4096;
+
+
+export const synthesizeGandr: SynthesizeBackendFn<SpeexWire_Access_Gandr> = async function* (params) {
+
+  // destructure and validate
+  const { access, text, voice, streaming, signal } = params;
+  if (access.dialect !== 'gandr' || voice.dialect !== 'gandr')
+    throw new Error('Mismatched dialect in Gandr synthesize');
+
+  // input cap: the API accepts up to 2000 characters per request
+  // (client-side text chunking keeps requests below the cap)
+  if (text.length > SPEEX_DEFAULTS.GANDR_MAX_LEN)
+    throw new Error(`Input exceeds the Gandr maximum of ${SPEEX_DEFAULTS.GANDR_MAX_LEN} characters per request`);
+
+  // build request - narrow to gandr dialect for type safety
+  const path = '/v1/audio/speech';
+  const { headers, url } = _gandrAccess(access, path);
+
+  const body: GandrWire.TTS_Request = {
+    model: voice.ttsModel || SPEEX_DEFAULTS.GANDR_MODEL,
+    input: text,
+    voice: voice.ttsVoiceId || SPEEX_DEFAULTS.GANDR_VOICE,
+    response_format: 'mp3',
+  } as const;
+
+  // Fetch
+  let response: Response;
+  try {
+    if (SPEEX_DEBUG) console.log(`[Speex][Gandr] POST (stream=${streaming})`, { url, headers, body });
+    response = await fetchResponseOrTRPCThrow({
+      url,
+      method: 'POST',
+      headers,
+      body,
+      signal,
+      name: 'Gandr',
+    });
+  } catch (error: any) {
+    yield { t: 'error', e: `Gandr fetch failed: ${error.message || 'Unknown error'}` };
+    return;
+  }
+
+  // Stream or return whole audio (with metadata for non-streaming)
+  try {
+    yield* streaming
+      ? streamAudioChunksOrThrow(response, MIN_CHUNK_SIZE, text.length)
+      : returnAudioWholeOrThrow(response, text.length, _parseTTSResponseHeaders(response.headers));
+  } catch (error: any) {
+    yield { t: 'error', e: `Gandr audio error: ${error.message || 'Unknown error'}` };
+  }
+};
+
+
+export function listVoicesGandr(): SpeexWire_VoiceOption[] {
+  return [
+    { id: 'gandr-mia', name: 'Mia', category: 'premade' },
+    { id: 'gandr-ava', name: 'Ava', category: 'premade' },
+    { id: 'gandr-jenny', name: 'Jenny', category: 'premade' },
+    { id: 'gandr-dane', name: 'Dane', category: 'premade' },
+    { id: 'gandr-leo', name: 'Leo', category: 'premade' },
+    { id: 'gandr-lewis', name: 'Lewis', category: 'premade' },
+  ];
+}
+
+
+// Helpers
+
+function _parseTTSResponseHeaders(headers: Headers): Pick<Extract<SpeexSpeechParticle, { t: 'audio' }>, 'contentType' | 'characterCost' | 'ttsLatencyMs'> {
+  return {
+    contentType: headers.get('content-type') || 'audio/mpeg',
+    characterCost: parseInt(headers.get('character-cost') || '0') || undefined,
+    ttsLatencyMs: parseInt(headers.get('tts-latency-ms') || '0') || undefined,
+  };
+}
+
+function _gandrAccess(access: SpeexWire_Access_Gandr, apiPath: string): { headers: HeadersInit; url: string } {
+  const apiKey = (access.apiKey /*|| env.GANDR_API_KEY */ || '').trim();
+  if (!apiKey)
+    throw new Error('Missing Gandr API key');
+
+  let host = (access.apiHost /*|| env.GANDR_API_HOST*/ || 'tts.gandr.ai').trim();
+  if (!host.startsWith('http'))
+    host = `https://${host}`;
+  if (host.endsWith('/') && apiPath.startsWith('/'))
+    host = host.slice(0, -1);
+
+  return {
+    headers: {
+      'Accept': 'audio/mpeg',
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    url: host + apiPath,
+  };
+}
+
+
+// Wire types for the upstream Gandr API
+
+namespace GandrWire {
+
+  export type TTS_Request = z.infer<typeof TTS_Request_schema>;
+  export const TTS_Request_schema = z.object({
+    model: z.string(),
+    input: z.string(),
+    voice: z.string(),
+    response_format: z.enum(['mp3', 'wav', 'pcm']).optional(),
+  });
+
+}

--- a/src/modules/speex/protocols/rpc/synthesize.core.ts
+++ b/src/modules/speex/protocols/rpc/synthesize.core.ts
@@ -10,6 +10,7 @@
 
 import type { SpeexSpeechParticle, SpeexWire_Access, SpeexWire_ListVoices_Output, SpeexWire_Synthesize_Input, SpeexWire_Voice } from './rpc.wiretypes';
 import { listVoicesElevenLabs, synthesizeElevenLabs } from './synthesize-elevenlabs';
+import { listVoicesGandr, synthesizeGandr } from './synthesize-gandr';
 import { listVoicesInworld, synthesizeInworld } from './synthesize-inworld';
 import { listVoicesLocalAIOrThrow, listVoicesOpenAI, synthesizeOpenAIProtocol } from './synthesize-openai';
 
@@ -47,6 +48,10 @@ export async function* speexRpcCoreSynthesize(input: SpeexWire_Synthesize_Input,
         yield* synthesizeElevenLabs({ access, text, voice, streaming, languageCode, priority, signal });
         break;
 
+      case 'gandr':
+        yield* synthesizeGandr({ access, text, voice, streaming, languageCode, priority, signal });
+        break;
+
       case 'inworld':
         yield* synthesizeInworld({ access, text, voice, streaming, languageCode, priority, signal });
         break;
@@ -72,6 +77,9 @@ export async function speexRpcCoreListVoices(access: SpeexWire_Access): Promise<
   switch (access.dialect) {
     case 'elevenlabs':
       return await listVoicesElevenLabs(access);
+
+    case 'gandr':
+      return { voices: listVoicesGandr() };
 
     case 'inworld':
       return await listVoicesInworld(access);

--- a/src/modules/speex/speex.config.ts
+++ b/src/modules/speex/speex.config.ts
@@ -19,6 +19,11 @@ export const SPEEX_DEFAULTS = {
   // - XrExE9yKIg1WjnnlVkGX: Matilda - Informative
   // - SAz9YHcvj6GT2YYXdXww: River - Conversational
 
+  // Gandr TTS - 6 preset voices, 23 languages
+  GANDR_MODEL: 'tts-1',
+  GANDR_VOICE: 'gandr-mia',
+  GANDR_MAX_LEN: 2000, // max chars per TTS request
+
   // LocalAI - kokoro is a high-quality neural TTS
   LOCALAI_MODEL: 'kokoro',
 

--- a/src/modules/speex/speex.types.ts
+++ b/src/modules/speex/speex.types.ts
@@ -8,7 +8,7 @@ import type { SpeexWire_VoiceOption } from './protocols/rpc/rpc.wiretypes';
 
 // Speex Vendor Types (supported TTS providers)
 
-export type DSpeexVendorType = 'elevenlabs' | 'inworld' | 'localai' | 'openai' | 'webspeech';
+export type DSpeexVendorType = 'elevenlabs' | 'gandr' | 'inworld' | 'localai' | 'openai' | 'webspeech';
 
 
 // Speex Engines - instances of TTS Vendors Types - persisted in store-module-speex
@@ -34,6 +34,7 @@ export type SpeexEngineId = string; // agiUuidV4('speex.engine.instance')
 // helper for mapping credentials and voice types to the engine type
 interface _TypeMap extends Record<DSpeexVendorType, { voice: unknown; credentials: unknown }> {
   'elevenlabs': { voice: DVoiceElevenLabs; credentials: DCredentialsApiKey };
+  'gandr': { voice: DVoiceGandr; credentials: DCredentialsApiKey };
   'inworld': { voice: DVoiceInworld; credentials: DCredentialsApiKey };
   'localai': { voice: DVoiceLocalAI; credentials: DCredentialsLLMSService | DCredentialsApiKey };
   'openai': { voice: DVoiceOpenAI; credentials: DCredentialsLLMSService | DCredentialsApiKey };
@@ -55,6 +56,12 @@ export interface DVoiceElevenLabs {
   // ttsSimilarityBoost?: number;
   // ttsStyle?: number;
   // ttsS?: boolean;
+}
+
+export interface DVoiceGandr {
+  dialect: 'gandr';
+  ttsModel?: 'tts-1';
+  ttsVoiceId?: 'gandr-mia' | 'gandr-ava' | 'gandr-jenny' | 'gandr-dane' | 'gandr-leo' | 'gandr-lewis' | string;
 }
 
 export interface DVoiceInworld {

--- a/src/modules/speex/speex.vendors-registry.ts
+++ b/src/modules/speex/speex.vendors-registry.ts
@@ -5,6 +5,7 @@ import type { ISpeexVendor, ISpeexVendorAny } from './ISpeexVendor';
 
 // vendor imports
 import { SpeexVendorElevenLabs } from './vendors/elevenlabs.vendor';
+import { SpeexVendorGandr } from './vendors/gandr.vendor';
 import { SpeexVendorInworld } from './vendors/inworld.vendor';
 import { SpeexVendorLocalAI } from './vendors/localai.vendor';
 import { SpeexVendorOpenAI } from './vendors/openai.vendor';
@@ -15,6 +16,7 @@ import { SpeexVendorWebSpeech } from './vendors/webspeech.vendor';
 
 const _SPEEX_VENDOR_REGISTRY: { [key in DSpeexVendorType]: ISpeexVendor<key> } = {
   elevenlabs: SpeexVendorElevenLabs,
+  gandr: SpeexVendorGandr,
   inworld: SpeexVendorInworld,
   localai: SpeexVendorLocalAI,
   openai: SpeexVendorOpenAI,

--- a/src/modules/speex/vendors/gandr.vendor.ts
+++ b/src/modules/speex/vendors/gandr.vendor.ts
@@ -1,0 +1,31 @@
+import type { ISpeexVendor } from '../ISpeexVendor';
+import { SPEEX_DEFAULTS } from '../speex.config';
+
+
+export const SpeexVendorGandr: ISpeexVendor<'gandr'> = {
+  vendorType: 'gandr',
+  name: 'Gandr',
+  protocol: 'rpc',
+  location: 'cloud',
+  priority: 25,
+
+  autoFromLlmVendorIds: undefined,
+
+  capabilities: {
+    streaming: true,
+    voiceListing: true,   // static premade list, served through the RPC listVoices route (no API call)
+    speedControl: false,
+    pitchControl: false,
+  },
+
+  getDefaultCredentials: () => ({
+    type: 'api-key',
+    apiKey: '',
+  }),
+
+  getDefaultVoice: () => ({
+    dialect: 'gandr',
+    ttsModel: SPEEX_DEFAULTS.GANDR_MODEL,
+    ttsVoiceId: SPEEX_DEFAULTS.GANDR_VOICE,
+  }),
+};

--- a/src/server/env.server.ts
+++ b/src/server/env.server.ts
@@ -122,6 +122,9 @@ export const env = createEnv({
     ELEVENLABS_API_HOST: z.url().optional(),
     ELEVENLABS_VOICE_ID: z.string().optional(),
 
+    // Text-To-Speech: Gandr
+    GANDR_API_KEY: z.string().optional(),
+
 
     // Backend: HTTP Basic Authentication
     HTTP_BASIC_AUTH_USERNAME: z.string().optional(),


### PR DESCRIPTION
Adds Gandr (https://gandr.ai) as a text-to-speech vendor in the Speex module, following the same structure as the existing ElevenLabs vendor.

What changed:
- New vendor definition src/modules/speex/vendors/gandr.vendor.ts: an ISpeexVendor<'gandr'> entry with RPC protocol, cloud location, shared API key credentials, and default voice gandr-mia on model tts-1.
- New synthesis handler src/modules/speex/protocols/rpc/synthesize-gandr.ts: posts to https://tts.gandr.ai/v1/audio/speech with Bearer auth and the JSON body model, input, voice, response_format, then streams or returns the audio response through the same helpers the ElevenLabs handler uses. Requests above the 2000 character per request input cap fail with a clear error. It also exports listVoicesGandr, a fixed premade list of the six voices, which the existing listVoices RPC route serves with no network call.
- Registration and types: gandr added to the vendor registry, to SPEEX_DEFAULTS, to the wire access and voice discriminated unions, to the persisted voice and credential type map, and to the synthesize.core.ts dispatch for both synthesize and listVoices. The tRPC speex router itself is unchanged.
- Environment: GANDR_API_KEY declared as an optional variable in src/server/env.server.ts and documented in docs/environment-variables.md.

File list:
- src/modules/speex/vendors/gandr.vendor.ts (new)
- src/modules/speex/protocols/rpc/synthesize-gandr.ts (new)
- src/modules/speex/speex.vendors-registry.ts (register the vendor)
- src/modules/speex/speex.config.ts (GANDR_MODEL, GANDR_VOICE, GANDR_MAX_LEN)
- src/modules/speex/protocols/rpc/rpc.wiretypes.ts (AccessGandr_schema, VoiceGandr_schema, union entries)
- src/modules/speex/speex.types.ts (DSpeexVendorType, _TypeMap entry, DVoiceGandr)
- src/modules/speex/protocols/rpc/synthesize.core.ts (gandr cases in the synthesize and listVoices dispatch)
- src/server/env.server.ts (GANDR_API_KEY declaration)
- docs/environment-variables.md (GANDR_API_KEY entry)

Notes on the pattern:
- Credentials reuse the shared DCredentialsApiKey shape (api key plus optional host override), so the existing engine settings UI renders it like any other API key vendor. The access helper keeps the same commented-out environment fallback the ElevenLabs handler uses, and the variable is already declared in env.server.ts.
- Voices are the six premade ids gandr-mia, gandr-ava, gandr-jenny, gandr-dane, gandr-leo, gandr-lewis. The default is gandr-mia, and the list is served through the standard listVoices route rather than a vendor API call.
- Supported response formats are mp3 (default), wav, and pcm. pcm is headerless s16le mono at 24000 Hz. The handler requests mp3.
- The API supports 23 languages, and every render is watermarked.

How to verify:
1. Apply the files at the pinned commit bebf1a6ba956bedaa434f1211f6d6142ef06df12.
2. npm install, then npm run tscheck for a clean type check.
3. npm run dev, open the Speex engine settings, add a Gandr engine, paste a key (gnd_...), keep the default voice, and run the built-in system test.
4. Direct API check independent of the app: curl -sS -X POST https://tts.gandr.ai/v1/audio/speech -H "Authorization: Bearer gnd_..." -H "Content-Type: application/json" -d '{"model":"tts-1","input":"Hello from big-AGI","voice":"gandr-mia","response_format":"mp3"}' -o /tmp/gandr-check.mp3
5. Keys are available at https://gandr.ai; the free tier is 50,000 tokens.

Disclosure: I work on Gandr.
