### PR TITLE
feat: add llmman vendor

### DIFF
--- a/src/modules/aix/server/dispatch/chatGenerate/chatGenerate.dispatch.ts
+++ b/src/modules/aix/server/dispatch/chatGenerate/chatGenerate.dispatch.ts
@@ -263,6 +263,7 @@ export async function createChatGenerateDispatch(access: AixAPI_Access, model: A
     case 'cohere':
     case 'deepseek':
     case 'groq':
+    case 'llmman':
     case 'lmstudio':
     case 'localai':
     case 'mistral':
@@ -385,6 +386,7 @@ export async function createChatGenerateResumeDispatch(access: AixAPI_Access, re
     case 'cohere':
     case 'deepseek':
     case 'groq':
+    case 'llmman':
     case 'lmstudio':
     case 'localai':
     case 'mistral':

--- a/src/modules/llms/components/LLMVendorIcon.tsx
+++ b/src/modules/llms/components/LLMVendorIcon.tsx
@@ -49,6 +49,7 @@ const vendorIcons: Record<ModelVendorId, React.FunctionComponent<SvgIconProps>> 
   deepseek: DeepseekIcon,
   googleai: GeminiIcon,
   groq: GroqIcon,
+  llmman: LMStudioIcon, // TODO: dedicated icon
   lmstudio: LMStudioIcon,
   localai: LocalAIIcon,
   mistral: MistralIcon,

--- a/src/modules/llms/components/LLMVendorIconSprite.tsx
+++ b/src/modules/llms/components/LLMVendorIconSprite.tsx
@@ -21,6 +21,7 @@ const VI: Record<ModelVendorId, string> = {
   deepseek: 'vi-deepseek',
   googleai: 'vi-googleai',
   groq: 'vi-groq',
+  llmman: 'vi-lmstudio', // TODO: dedicated sprite
   lmstudio: 'vi-lmstudio',
   localai: 'vi-localai',
   mistral: 'vi-mistral',

--- a/src/modules/llms/components/LLMVendorSetup.tsx
+++ b/src/modules/llms/components/LLMVendorSetup.tsx
@@ -16,6 +16,7 @@ import { CohereServiceSetup } from '../vendors/cohere/CohereServiceSetup';
 import { DeepseekAIServiceSetup } from '../vendors/deepseek/DeepseekAIServiceSetup';
 import { GeminiServiceSetup } from '../vendors/gemini/GeminiServiceSetup';
 import { GroqServiceSetup } from '../vendors/groq/GroqServiceSetup';
+import { LlmmanServiceSetup } from '../vendors/llmman/LlmmanServiceSetup';
 import { LMStudioServiceSetup } from '../vendors/lmstudio/LMStudioServiceSetup';
 import { LocalAIServiceSetup } from '../vendors/localai/LocalAIServiceSetup';
 import { MistralServiceSetup } from '../vendors/mistral/MistralServiceSetup';
@@ -47,6 +48,7 @@ const vendorSetupComponents: Record<ModelVendorId, React.ComponentType<{ service
   deepseek: DeepseekAIServiceSetup,
   googleai: GeminiServiceSetup,
   groq: GroqServiceSetup,
+  llmman: LlmmanServiceSetup,
   lmstudio: LMStudioServiceSetup,
   localai: LocalAIServiceSetup,
   mistral: MistralServiceSetup,
@@ -78,6 +80,8 @@ export const VENDOR_DOCS: Record<ModelVendorId, SiteDocSlug> = {
   deepseek: 'connect-deepseek',
   googleai: 'connect-gemini',
   groq: 'connect-groq',
+  // No dedicated page yet; point at the general guide until one exists in the website repo.
+  llmman: 'connect-models',
   lmstudio: 'connect-lmstudio',
   localai: 'connect-localai',
   mistral: 'connect-mistral',

--- a/src/modules/llms/server/gen/llms.defs.versions.ts
+++ b/src/modules/llms/server/gen/llms.defs.versions.ts
@@ -19,6 +19,7 @@ export const LLMS_DEFS_VERSIONS = {
   deepseek: '4879f9ce4449',
   googleai: '93fff1905b8d',
   groq: '164ebcb47b72',
+  llmman: '9955dea7114b',
   lmstudio: '85eb57eb8e42',
   localai: '2a8b423c867f',
   mistral: '694524773ba1',

--- a/src/modules/llms/server/listModels.dispatch.ts
+++ b/src/modules/llms/server/listModels.dispatch.ts
@@ -50,6 +50,7 @@ import { nousResearchHeuristic, nousResearchModelsToModelDescriptions } from './
 import { novitaHeuristic, novitaModelsToModelDescriptions } from './openai/models/novita.models';
 import { nvidiaNIMHeuristic, nvidiaNIMModelsToModelDescriptions } from './openai/models/nvidianim.models';
 import { lmStudioFetchModels, lmStudioModelsToModelDescriptions } from './openai/models/lmstudio.models';
+import { llmmanModelSortFn, llmmanModelToModelDescription } from './openai/models/llmman.models';
 import { localAIModelSortFn, localAIModelToModelDescription } from './openai/models/localai.models';
 import { mistralModels } from './openai/models/mistral.models';
 import { modularModelsToModelDescriptions } from './openai/models/modular.models';
@@ -387,6 +388,7 @@ function _listModelsCreateDispatch(access: AixAPI_Access, signal?: AbortSignal):
     case 'cohere':
     case 'deepseek':
     case 'groq':
+    case 'llmman':
     case 'localai':
     case 'mistral':
     case 'modular':
@@ -483,6 +485,11 @@ function _listModelsCreateDispatch(access: AixAPI_Access, signal?: AbortSignal):
                 .filter(groqModelFilter)
                 .map(groqModelToModelDescription)
                 .sort(groqModelSortFn);
+
+            case 'llmman':
+              return maybeModels
+                .map(({ id }) => llmmanModelToModelDescription(id))
+                .sort(llmmanModelSortFn);
 
             case 'localai':
               return maybeModels

--- a/src/modules/llms/server/llms.defs.manifest.ts
+++ b/src/modules/llms/server/llms.defs.manifest.ts
@@ -49,6 +49,7 @@ export const LLMS_DEFS_MANIFEST = {
   deepseek: { files: ['openai/models/deepseek.models.ts'] },
   googleai: { files: ['gemini/gemini.models.ts'] },
   groq: { files: ['openai/models/groq.models.ts', 'openai/wiretypes/groq.wiretypes.ts'] },
+  llmman: { files: ['openai/models/llmman.models.ts'] },
   lmstudio: { files: ['openai/models/lmstudio.models.ts'] },
   localai: { files: ['openai/models/localai.models.ts'] },
   mistral: { files: ['openai/models/mistral.models.ts'] },

--- a/src/modules/llms/server/openai/models/llmman.models.ts
+++ b/src/modules/llms/server/openai/models/llmman.models.ts
@@ -1,0 +1,36 @@
+import { LLM_IF_OAI_Chat, LLM_IF_OAI_Fn, LLM_IF_OAI_Reasoning, LLM_IF_OAI_Vision } from '~/common/stores/llms/llms.types';
+
+import type { ModelDescriptionSchema } from '../../llm.server.types';
+
+
+// [llmman] Models are whatever the user has pulled locally, so ids are not from
+// a fixed catalog and no manual mapping table applies. Served locally, so free.
+const _llmmanPrice = { input: 'free', output: 'free' } as const;
+
+
+export function llmmanModelSortFn(a: ModelDescriptionSchema, b: ModelDescriptionSchema): number {
+  return a.label.localeCompare(b.label);
+}
+
+export function llmmanModelToModelDescription(modelId: string): ModelDescriptionSchema {
+  const label = modelId;
+
+  // Very dull heuristics, matching how the other local vendors infer capabilities
+  // from an id, since the server reports no capability metadata.
+  const lowerId = modelId.toLowerCase();
+  const interfaces = [LLM_IF_OAI_Chat, LLM_IF_OAI_Fn];
+  if (['vision', 'llava', '-vl-', 'minicpm-v'].some(match => lowerId.includes(match)))
+    interfaces.push(LLM_IF_OAI_Vision);
+  if (['r1', 'thinking', 'reasoning', 'qwq'].some(match => lowerId.includes(match)))
+    interfaces.push(LLM_IF_OAI_Reasoning);
+
+  return {
+    id: modelId,
+    label,
+    created: 0,
+    description: `Local model served by llmman. Id: ${modelId}`,
+    contextWindow: null, // not reported
+    interfaces,
+    chatPrice: _llmmanPrice,
+  };
+}

--- a/src/modules/llms/server/openai/openai.access.ts
+++ b/src/modules/llms/server/openai/openai.access.ts
@@ -4,7 +4,7 @@
  * This module only imports zod for schema definition and provides access logic
  * that works identically on server and client environments.
  *
- * Supports 19 OpenAI-compatible dialects: alibaba, azure, cerebras, cohere, deepseek, groq, lmstudio,
+ * Supports 20 OpenAI-compatible dialects: alibaba, azure, cerebras, cohere, deepseek, groq, llmman, lmstudio,
  * localai, mistral, modular, moonshot, nvidianim, openai, openrouter, perplexity, sakanaai, togetherai,
  * xai, zai
  */
@@ -26,6 +26,7 @@ const DEFAULT_CEREBRAS_HOST = 'https://api.cerebras.ai';
 const DEFAULT_COHERE_HOST = 'https://api.cohere.ai/compatibility';
 const DEFAULT_DEEPSEEK_HOST = 'https://api.deepseek.com';
 const DEFAULT_GROQ_HOST = 'https://api.groq.com/openai';
+const DEFAULT_LLMMAN_HOST = 'http://localhost:17434';
 const DEFAULT_LMSTUDIO_HOST = 'http://localhost:1234';
 const DEFAULT_LOCALAI_HOST = 'http://127.0.0.1:8080';
 const DEFAULT_MISTRAL_HOST = 'https://api.mistral.ai';
@@ -45,7 +46,7 @@ const DEFAULT_ZAI_HOST = 'https://api.z.ai/api/paas';
 // -- Centralized OpenAI-compatible API Paths --
 // These are the standard paths used across all OpenAI-compatible dialects.
 // Some dialects (perplexity, cloudflare, azure) have custom path handling.
-// Dialects with user-configurable hosts (lmstudio, localai, openai, ollama) support
+// Dialects with user-configurable hosts (llmman, lmstudio, localai, openai, ollama) support
 // custom base paths - when the host URL contains a path, /v1 is stripped.
 
 export const OPENAI_API_PATHS = {
@@ -94,7 +95,7 @@ export type OpenAIDialects = OpenAIAccessSchema['dialect'];
 export type OpenAIAccessSchema = z.infer<typeof openAIAccessSchema>;
 export const openAIAccessSchema = z.object({
   dialect: z.enum([
-    'alibaba', 'azure', 'cerebras', 'cohere', 'deepseek', 'groq', 'lmstudio',
+    'alibaba', 'azure', 'cerebras', 'cohere', 'deepseek', 'groq', 'llmman', 'lmstudio',
     'localai', 'mistral', 'modular', 'moonshot', 'nvidianim', 'openai',
     'openrouter', 'perplexity', 'sakanaai', 'togetherai', 'xai', 'zai',
   ]),
@@ -206,6 +207,18 @@ export function openAIAccess(access: OpenAIAccessSchema, modelRefId: string | nu
           'Authorization': `Bearer ${groqKey}`,
         },
         url: groqHost + apiPath,
+      };
+
+    case 'llmman':
+      // llmman serves an OpenAI-compatible API; no key is required.
+      const llmmanKey = access.oaiKey || '';
+      let llmmanHost = llmsFixupHost(access.oaiHost || DEFAULT_LLMMAN_HOST, apiPath);
+      return {
+        headers: {
+          'Content-Type': 'application/json',
+          ...(llmmanKey && { Authorization: `Bearer ${llmmanKey}` }),
+        },
+        url: llmmanHost + apiPath,
       };
 
     case 'lmstudio':

--- a/src/modules/llms/vendors/llmman/LlmmanServiceSetup.tsx
+++ b/src/modules/llms/vendors/llmman/LlmmanServiceSetup.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import * as z from 'zod/v4';
+
+import { Typography } from '@mui/joy';
+import YouTubeIcon from '@mui/icons-material/YouTube';
+
+import type { DModelsServiceId } from '~/common/stores/llms/llms.service.types';
+import { ExpanderAccordion } from '~/common/components/ExpanderAccordion';
+import { ExternalDocsLink } from '~/common/components/ExternalDocsLink';
+import { FormInputKey } from '~/common/components/forms/FormInputKey';
+import { InlineError } from '~/common/components/InlineError';
+import { isLocalUrl } from '~/common/util/urlUtils';
+import { Link } from '~/common/components/Link';
+import { SetupFormClientSideToggle } from '~/common/components/forms/SetupFormClientSideToggle';
+import { SetupFormCorsHint } from '~/common/components/forms/SetupFormCorsHint';
+import { SetupFormRefetchButton } from '~/common/components/forms/SetupFormRefetchButton';
+import { VideoPlayerYouTube } from '~/common/components/VideoPlayerYouTube';
+
+import { useLlmUpdateModels } from '../../llm.client.hooks';
+import { useServiceSetup } from '../useServiceSetup';
+
+import { ModelVendorLlmman } from './llmman.vendor';
+
+
+export function LlmmanServiceSetup(props: { serviceId: DModelsServiceId }) {
+
+  // external state
+  const { service, serviceAccess, updateSettings } =
+    useServiceSetup(props.serviceId, ModelVendorLlmman);
+
+  // derived state
+  const { clientSideFetch, oaiHost } = serviceAccess;
+
+  // validate if url is a well formed proper url with zod
+  const urlSchema = z.url().startsWith('http');
+  const { success: isValidHost } = urlSchema.safeParse(oaiHost);
+  const shallFetchSucceed = isValidHost;
+
+  // fetch models - the OpenAI way
+  const { isFetching, refetch, isError, error } =
+    useLlmUpdateModels(false /* use button only (we don't have server-side conf) */, service);
+
+  return <>
+
+    <ExpanderAccordion
+      title={<Typography level='title-sm' sx={{ mr: 'auto' }}>Video Tutorial</Typography>}
+      icon={<YouTubeIcon sx={{ color: '#f00' }} />}
+      // expandedVariant='solid'
+      startCollapsed
+    >
+      {/* play='auto': the accordion-expand click grants unmuted autoplay (the embed mounts on reveal, via its visibility gate), like the pre-2026-07 behavior */}
+      <VideoPlayerYouTube width='100%' height={360} youTubeVideoId='MqXzxVokMDk' title='Running big-AGI locally with llmman [TUTORIAL]' play='auto' rounded />
+    </ExpanderAccordion>
+
+    <Typography level='body-sm'>
+      You can use a running <Link href='https://llmman.ai/' target='_blank'>llmman</Link> instance as a source
+      for local models. Please refer to our <ExternalDocsLink level='body-sm' docPage='connect-models'>configuration guide</ExternalDocsLink> for
+      how to link to your llmman instance.
+    </Typography>
+
+    <FormInputKey
+      autoCompleteId='llmman-url' label='llmman API'
+      required noKey
+      rightLabel={<ExternalDocsLink level='body-sm' docPage='connect-models'>Learn more</ExternalDocsLink>}
+      placeholder='e.g., http://127.0.0.1:17434'
+      value={oaiHost} onChange={value => updateSettings({ oaiHost: value })}
+    />
+
+    {/* [2026-08-23] not behind 'Advanced': a LAN/localhost llmman is only reachable from the browser, so this is the primary control (same as LocalAI/Ollama) */}
+    <SetupFormClientSideToggle
+      visible={true}
+      checked={!!clientSideFetch}
+      onChange={on => updateSettings({ csf: on })}
+      helpText='Fetch models and make requests directly from your llmman instance using the browser. Recommended for local setups - requires CORS enabled in llmman (Developer > Server Settings).'
+      localHostDetected={isLocalUrl(oaiHost)}
+    />
+
+    <SetupFormRefetchButton refetch={refetch} disabled={!shallFetchSucceed || isFetching} loading={isFetching} error={isError} />
+
+    <SetupFormCorsHint visible={isError && !!clientSideFetch}>
+      Make sure CORS is enabled on the llmman server. Open the <b>Developer</b> tab, press <b>Server Settings</b>, and turn on <b>Enable CORS</b>.
+    </SetupFormCorsHint>
+
+    {isError && <InlineError error={error} />}
+
+  </>;
+}

--- a/src/modules/llms/vendors/llmman/llmman.vendor.ts
+++ b/src/modules/llms/vendors/llmman/llmman.vendor.ts
@@ -1,0 +1,44 @@
+import type { IModelVendor } from '../IModelVendor';
+import type { OpenAIAccessSchema } from '../../server/openai/openai.access';
+
+import { ModelVendorOpenAI } from '../openai/openai.vendor';
+
+
+interface DLlmmanServiceSettings {
+  oaiHost: string;  // use OpenAI-compatible non-default hosts (full origin path)
+  csf?: boolean;
+}
+
+export const ModelVendorLlmman: IModelVendor<DLlmmanServiceSettings, OpenAIAccessSchema> = {
+  id: 'llmman',
+  name: 'llmman',
+  displayRank: 53,
+  displayGroup: 'local',
+  location: 'local',
+  instanceLimit: 1,
+
+  /// client-side-fetch ///
+  csfAvailable: _csfLlmmanAvailable,
+
+  // functions
+  initializeSetup: () => ({
+    oaiHost: 'http://localhost:17434',
+  }),
+  getTransportAccess: (partialSetup) => ({
+    dialect: 'llmman',
+    clientSideFetch: _csfLlmmanAvailable(partialSetup) && !!partialSetup?.csf,
+    oaiKey: '',
+    oaiOrg: '',
+    oaiHost: partialSetup?.oaiHost || '',
+  }),
+
+  // OpenAI transport ('llmman' dialect in 'access')
+  rpcUpdateModelsOrThrow: ModelVendorOpenAI.rpcUpdateModelsOrThrow,
+
+};
+
+function _csfLlmmanAvailable(_s?: Partial<DLlmmanServiceSettings>) {
+  // always available for local vendors - LM Studio defaults to http://localhost:17434
+  // was: return !!s?.oaiHost;
+  return true;
+}

--- a/src/modules/llms/vendors/vendors.registry.ts
+++ b/src/modules/llms/vendors/vendors.registry.ts
@@ -9,6 +9,7 @@ import { ModelVendorCohere } from './cohere/cohere.vendor';
 import { ModelVendorDeepseek } from './deepseek/deepseekai.vendor';
 import { ModelVendorGemini } from './gemini/gemini.vendor';
 import { ModelVendorGroq } from './groq/groq.vendor';
+import { ModelVendorLlmman } from './llmman/llmman.vendor';
 import { ModelVendorLMStudio } from './lmstudio/lmstudio.vendor';
 import { ModelVendorLocalAI } from './localai/localai.vendor';
 import { ModelVendorMistral } from './mistral/mistral.vendor';
@@ -37,6 +38,7 @@ export type ModelVendorId =
   | 'deepseek'
   | 'googleai'
   | 'groq'
+  | 'llmman'
   | 'lmstudio'
   | 'localai'
   | 'mistral'
@@ -64,6 +66,7 @@ const MODEL_VENDOR_REGISTRY = {
   deepseek: ModelVendorDeepseek,
   googleai: ModelVendorGemini,
   groq: ModelVendorGroq,
+  llmman: ModelVendorLlmman,
   lmstudio: ModelVendorLMStudio,
   localai: ModelVendorLocalAI,
   mistral: ModelVendorMistral,


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), which runs local models distributed as OCI artifacts and serves an **OpenAI-compatible API** on port 17434 (alongside Ollama- and Anthropic-compatible ones). It's a new dialect on the existing OpenAI transport rather than a new transport.

Models are whatever the user has pulled locally, so ids come from `/v1/models` and capabilities are inferred from the id using the same heuristics the other local vendors use — the server reports no capability metadata.

**Two things I'd like your call on:**
- The **icon and sprite reuse an existing local-vendor mark**, since there's no llmman asset in the repo. Happy to add one if you tell me the format you want.
- `VENDOR_DOCS` is deliberately exhaustive and `SiteDocSlug` is generated in the website repo, so I pointed llmman at the general `connect-models` page rather than inventing a `connect-llmman` slug that has no page behind it. If you'd rather have a real page first, say so and I'll hold.

**Testing:** `tsc --noEmit` is clean, and clean on a stashed baseline too. The exhaustive `never` checks earned their keep here — they caught four registration sites I'd otherwise have missed (both `chatGenerate.dispatch` switches, the generic listing switch, and the manifest). `llms.defs.versions.ts` was produced by `tools/develop/gen-llms-defs/generate-llms-defs.mjs`, but the generator rerolled every vendor's hash in my environment, so I reverted that and kept only the new `llmman` line to keep the diff reviewable.

Not verified: no run against a live server.

> AI-assisted, reviewed before submitting.
